### PR TITLE
Unload sent chunks outside ticking range

### DIFF
--- a/src/network/mcpe/NetworkSession.php
+++ b/src/network/mcpe/NetworkSession.php
@@ -205,6 +205,12 @@ class NetworkSession{
 	private ?InventoryManager $invManager = null;
 
 	/**
+	 * @var true[][]
+	 * @phpstan-var array<int, array<int, true>>
+	 */
+	private array $usedChunkCacheReferences = [];
+
+	/**
 	 * @var \Closure[]|ObjectSet
 	 * @phpstan-var ObjectSet<\Closure() : void>
 	 */
@@ -1281,7 +1287,14 @@ class NetworkSession{
 	 */
 	public function startUsingChunk(int $chunkX, int $chunkZ, \Closure $onCompletion) : void{
 		$world = $this->player->getLocation()->getWorld();
-		$promiseOrPacket = ChunkCache::getInstance($world, $this->compressor)->request($chunkX, $chunkZ);
+		$chunkCache = ChunkCache::getInstance($world, $this->compressor);
+		$worldId = $world->getId();
+		$chunkHash = World::chunkHash($chunkX, $chunkZ);
+		if(!isset($this->usedChunkCacheReferences[$worldId][$chunkHash])){
+			$this->usedChunkCacheReferences[$worldId][$chunkHash] = true;
+			$chunkCache->retain($chunkX, $chunkZ);
+		}
+		$promiseOrPacket = $chunkCache->request($chunkX, $chunkZ);
 		if(is_string($promiseOrPacket)){
 			$this->sendChunkPacket($promiseOrPacket, $onCompletion, $world);
 			return;
@@ -1309,8 +1322,20 @@ class NetworkSession{
 		);
 	}
 
-	public function stopUsingChunk(int $chunkX, int $chunkZ) : void{
-
+	public function stopUsingChunk(int $chunkX, int $chunkZ, ?World $world = null) : void{
+		$world ??= $this->player?->getLocation()->getWorld();
+		if($world === null){
+			return;
+		}
+		$worldId = $world->getId();
+		$chunkHash = World::chunkHash($chunkX, $chunkZ);
+		if(isset($this->usedChunkCacheReferences[$worldId][$chunkHash])){
+			unset($this->usedChunkCacheReferences[$worldId][$chunkHash]);
+			if(count($this->usedChunkCacheReferences[$worldId]) === 0){
+				unset($this->usedChunkCacheReferences[$worldId]);
+			}
+			ChunkCache::getInstance($world, $this->compressor)->release($chunkX, $chunkZ);
+		}
 	}
 
 	public function onEnterWorld() : void{

--- a/src/network/mcpe/cache/ChunkCache.php
+++ b/src/network/mcpe/cache/ChunkCache.php
@@ -54,6 +54,7 @@ class ChunkCache implements ChunkListener{
 			$world->addOnUnloadCallback(static function() use ($worldId) : void{
 				foreach(self::$instances[$worldId] as $cache){
 					$cache->caches = [];
+					$cache->usageCounts = [];
 				}
 				unset(self::$instances[$worldId]);
 				\GlobalLogger::get()->debug("Destroyed chunk packet caches for world#$worldId");
@@ -84,6 +85,11 @@ class ChunkCache implements ChunkListener{
 	 * @phpstan-var array<int, CompressBatchPromise|string>
 	 */
 	private array $caches = [];
+	/**
+	 * @var int[]
+	 * @phpstan-var array<int, int>
+	 */
+	private array $usageCounts = [];
 
 	private int $hits = 0;
 	private int $misses = 0;
@@ -96,6 +102,24 @@ class ChunkCache implements ChunkListener{
 		private Compressor $compressor,
 		private int $dimensionId = DimensionIds::OVERWORLD
 	){}
+
+	public function retain(int $chunkX, int $chunkZ) : void{
+		$chunkHash = World::chunkHash($chunkX, $chunkZ);
+		$this->usageCounts[$chunkHash] = ($this->usageCounts[$chunkHash] ?? 0) + 1;
+	}
+
+	public function release(int $chunkX, int $chunkZ) : void{
+		$chunkHash = World::chunkHash($chunkX, $chunkZ);
+		if(isset($this->usageCounts[$chunkHash])){
+			if($this->usageCounts[$chunkHash] === 1){
+				unset($this->usageCounts[$chunkHash]);
+				$this->destroy($chunkX, $chunkZ);
+				$this->world->unregisterChunkListener($this, $chunkX, $chunkZ);
+			}else{
+				--$this->usageCounts[$chunkHash];
+			}
+		}
+	}
 
 	private function prepareChunkAsync(int $chunkX, int $chunkZ, int $chunkHash) : CompressBatchPromise{
 		$this->world->registerChunkListener($this, $chunkX, $chunkZ);
@@ -203,6 +227,9 @@ class ChunkCache implements ChunkListener{
 	 * @see ChunkListener::onChunkUnloaded()
 	 */
 	public function onChunkUnloaded(int $chunkX, int $chunkZ, Chunk $chunk) : void{
+		if(($this->usageCounts[World::chunkHash($chunkX, $chunkZ)] ?? 0) > 0){
+			return;
+		}
 		$this->destroy($chunkX, $chunkZ);
 		$this->world->unregisterChunkListener($this, $chunkX, $chunkZ);
 	}

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -839,7 +839,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 					$entity->despawnFrom($this);
 				}
 			}
-			$this->getNetworkSession()->stopUsingChunk($x, $z);
+			$this->getNetworkSession()->stopUsingChunk($x, $z, $world);
 			unset($this->usedChunks[$index]);
 			unset($this->activeChunkGenerationRequests[$index]);
 		}
@@ -916,7 +916,7 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 					unset($this->activeChunkGenerationRequests[$index]);
 					$this->usedChunks[$index] = UsedChunkStatus::REQUESTED_SENDING;
 
-					$this->getNetworkSession()->startUsingChunk($X, $Z, function() use ($X, $Z, $index) : void{
+					$this->getNetworkSession()->startUsingChunk($X, $Z, function() use ($X, $Z, $index, $world) : void{
 						$this->usedChunks[$index] = UsedChunkStatus::SENT;
 						if($this->spawnChunkLoadCount === -1){
 							$this->spawnEntitiesOnChunk($X, $Z);
@@ -928,6 +928,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 							$this->getNetworkSession()->notifyTerrainReady();
 						}
 						(new PlayerPostChunkSendEvent($this, $X, $Z))->call();
+						if(isset($this->usedChunks[$index]) && !$this->isChunkNeededForTicking($X, $Z)){
+							$world->unregisterChunkLoader($this->chunkLoader, $X, $Z);
+							$world->unloadChunk($X, $Z, true);
+						}
 					});
 				},
 				static function() : void{
@@ -983,6 +987,33 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		if($this->getHealth() <= 0){
 			$this->logger->debug("Quit while dead, forcing respawn");
 			$this->actuallyRespawn();
+		}
+	}
+
+	private function isChunkNeededForTicking(int $chunkX, int $chunkZ) : bool{
+		for($x = -1; $x <= 1; ++$x){
+			for($z = -1; $z <= 1; ++$z){
+				if(isset($this->tickingChunks[World::chunkHash($chunkX + $x, $chunkZ + $z)])){
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private function updateChunkLoaderRegistrations() : void{
+		$world = $this->getWorld();
+		foreach($this->usedChunks as $hash => $status){
+			if($status === UsedChunkStatus::SENT){
+				World::getXZ($hash, $chunkX, $chunkZ);
+				if($this->isChunkNeededForTicking($chunkX, $chunkZ)){
+					$world->registerChunkLoader($this->chunkLoader, $chunkX, $chunkZ);
+				}else{
+					$world->unregisterChunkLoader($this->chunkLoader, $chunkX, $chunkZ);
+					$world->unloadChunk($chunkX, $chunkZ, true);
+				}
+			}
 		}
 	}
 
@@ -1050,8 +1081,10 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 
 		$this->loadQueue = $newOrder;
 
-		$this->updateTickingChunkRegistrations($this->tickingChunks, $tickingChunks);
+		$oldTickingChunks = $this->tickingChunks;
+		$this->updateTickingChunkRegistrations($oldTickingChunks, $tickingChunks);
 		$this->tickingChunks = $tickingChunks;
+		$this->updateChunkLoaderRegistrations();
 
 		if(count($this->loadQueue) > 0 || count($unloadChunks) > 0){
 			$this->getNetworkSession()->syncViewAreaCenterPoint($this->location, $this->viewDistance);
@@ -2950,7 +2983,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 	}
 
 	public function onChunkUnloaded(int $chunkX, int $chunkZ, Chunk $chunk) : void{
+		$hash = World::chunkHash($chunkX, $chunkZ);
 		if($this->isUsingChunk($chunkX, $chunkZ)){
+			if(($this->usedChunks[$hash] ?? null) === UsedChunkStatus::SENT && !$this->isChunkNeededForTicking($chunkX, $chunkZ)){
+				return;
+			}
 			$this->logger->debug("Detected forced unload of chunk " . $chunkX . " " . $chunkZ);
 			$this->unloadChunk($chunkX, $chunkZ);
 		}


### PR DESCRIPTION
### Related issues & PRs
* Fixes https://github.com/pmmp/PocketMine-MP/issues/6999


### Behavioural changes
Great ram usage decrease in servers that have large open worlds, and high render distances

## Tests
Tested in game, works.
Loaded chunks at view-distance 16:
- Unfixed: 856
- Fixed: **64**

Loaded chunks at view-distance 24:
- Unfixed: 1884
- Fixed: **64**, while client sees farther

In both tests, the ticking chunks remained at 36 (chunk radius: 3)