### PR TITLE
fix: 1.26.40 recipe visibility and shulker dyeing NBT

### DIFF
--- a/src/crafting/CraftingResultTransfer.php
+++ b/src/crafting/CraftingResultTransfer.php
@@ -27,16 +27,18 @@ namespace pocketmine\crafting;
 
 use pocketmine\block\tile\Container;
 use pocketmine\item\Item;
+use pocketmine\nbt\tag\CompoundTag;
+use function count;
 
 /**
- * Copies NBT from container crafting inputs onto recipe results.
- * This is needed for things like dyeing shulker boxes, which store their inventory
- * in the item's root named tag (Items), not in BlockEntityTag.
+ * Helper for recipes whose outputs must inherit container NBT from inputs (e.g. dyeing shulkers).
+ * Shulker contents live under the root Items tag; we also mirror them into BlockEntityTag.
  */
 final class CraftingResultTransfer{
 
 	/**
-	 * If an input has an Items tag, copies that input's named tag onto all results.
+	 * Merges Items/Lock (and custom name/lore) from the first matching input onto all results.
+	 * Only the container tags are touched — existing result NBT is otherwise preserved.
 	 *
 	 * @param Item[] $inputs
 	 * @param Item[] $results
@@ -45,12 +47,36 @@ final class CraftingResultTransfer{
 	 */
 	public static function transferContainerNamedTag(array $inputs, array $results) : void{
 		foreach($inputs as $input){
-			if($input->getNamedTag()->getTag(Container::TAG_ITEMS) === null){
+			$inputTag = $input->getNamedTag();
+			$itemsTag = $inputTag->getTag(Container::TAG_ITEMS);
+			if($itemsTag === null){
 				continue;
 			}
-			$tag = clone $input->getNamedTag();
+
+			$lockTag = $inputTag->getTag(Container::TAG_LOCK);
 			foreach($results as $result){
-				$result->setNamedTag(clone $tag);
+				$resultTag = $result->getNamedTag();
+				$resultTag->setTag(Container::TAG_ITEMS, clone $itemsTag);
+
+				$blockEntityTag = $result->getCustomBlockData() ?? new CompoundTag();
+				$blockEntityTag->setTag(Container::TAG_ITEMS, clone $itemsTag);
+
+				if($lockTag !== null){
+					$resultTag->setTag(Container::TAG_LOCK, clone $lockTag);
+					$blockEntityTag->setTag(Container::TAG_LOCK, clone $lockTag);
+				}else{
+					$resultTag->removeTag(Container::TAG_LOCK);
+					$blockEntityTag->removeTag(Container::TAG_LOCK);
+				}
+				$result->setCustomBlockData($blockEntityTag);
+
+				if($input->hasCustomName()){
+					$result->setCustomName($input->getCustomName());
+				}
+				$lore = $input->getLore();
+				if(count($lore) > 0){
+					$result->setLore($lore);
+				}
 			}
 			return;
 		}

--- a/src/crafting/CraftingResultTransfer.php
+++ b/src/crafting/CraftingResultTransfer.php
@@ -40,8 +40,8 @@ final class CraftingResultTransfer{
 	 *
 	 * @param Item[] $inputs
 	 * @param Item[] $results
-	 * @phpstan-param list<Item> $inputs
-	 * @phpstan-param list<Item> $results
+	 * @phpstan-param array<int, Item> $inputs
+	 * @phpstan-param array<int, Item> $results
 	 */
 	public static function transferContainerNamedTag(array $inputs, array $results) : void{
 		foreach($inputs as $input){

--- a/src/crafting/CraftingResultTransfer.php
+++ b/src/crafting/CraftingResultTransfer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\crafting;
+
+use pocketmine\block\tile\Container;
+use pocketmine\item\Item;
+
+/**
+ * Copies NBT from container crafting inputs onto recipe results.
+ * This is needed for things like dyeing shulker boxes, which store their inventory
+ * in the item's root named tag (Items), not in BlockEntityTag.
+ */
+final class CraftingResultTransfer{
+
+	/**
+	 * If an input has an Items tag, copies that input's named tag onto all results.
+	 *
+	 * @param Item[] $inputs
+	 * @param Item[] $results
+	 * @phpstan-param list<Item> $inputs
+	 * @phpstan-param list<Item> $results
+	 */
+	public static function transferContainerNamedTag(array $inputs, array $results) : void{
+		foreach($inputs as $input){
+			if($input->getNamedTag()->getTag(Container::TAG_ITEMS) === null){
+				continue;
+			}
+			$tag = clone $input->getNamedTag();
+			foreach($results as $result){
+				$result->setNamedTag(clone $tag);
+			}
+			return;
+		}
+	}
+}

--- a/src/crafting/ShapedRecipe.php
+++ b/src/crafting/ShapedRecipe.php
@@ -134,19 +134,7 @@ class ShapedRecipe implements CraftingRecipe{
 	 */
 	public function getResultsFor(CraftingGrid $grid) : array{
 		$results = $this->getResults();
-
-		for($y = 0, $height = $grid->getRecipeHeight(); $y < $height; ++$y){
-			for($x = 0, $width = $grid->getRecipeWidth(); $x < $width; ++$x){
-				$inputItem = $grid->getIngredient($x, $y);
-				if($inputItem->hasCustomBlockData()){
-					foreach($results as $result){
-						$result->setCustomBlockData($inputItem->getCustomBlockData());
-					}
-					return $results;
-				}
-			}
-		}
-
+		CraftingResultTransfer::transferContainerNamedTag($grid->getContents(), $results);
 		return $results;
 	}
 

--- a/src/crafting/ShapedRecipe.php
+++ b/src/crafting/ShapedRecipe.php
@@ -133,7 +133,21 @@ class ShapedRecipe implements CraftingRecipe{
 	 * @phpstan-return list<Item>
 	 */
 	public function getResultsFor(CraftingGrid $grid) : array{
-		return $this->getResults();
+		$results = $this->getResults();
+
+		for($y = 0, $height = $grid->getRecipeHeight(); $y < $height; ++$y){
+			for($x = 0, $width = $grid->getRecipeWidth(); $x < $width; ++$x){
+				$inputItem = $grid->getIngredient($x, $y);
+				if($inputItem->hasCustomBlockData()){
+					foreach($results as $result){
+						$result->setCustomBlockData($inputItem->getCustomBlockData());
+					}
+					return $results;
+				}
+			}
+		}
+
+		return $results;
 	}
 
 	/**

--- a/src/crafting/ShapelessRecipe.php
+++ b/src/crafting/ShapelessRecipe.php
@@ -71,16 +71,7 @@ class ShapelessRecipe implements CraftingRecipe{
 
 	public function getResultsFor(CraftingGrid $grid) : array{
 		$results = $this->getResults();
-
-		foreach($grid->getContents() as $inputItem){
-			if($inputItem->hasCustomBlockData()){
-				foreach($results as $result){
-					$result->setCustomBlockData($inputItem->getCustomBlockData());
-				}
-				break;
-			}
-		}
-
+		CraftingResultTransfer::transferContainerNamedTag($grid->getContents(), $results);
 		return $results;
 	}
 

--- a/src/crafting/ShapelessRecipe.php
+++ b/src/crafting/ShapelessRecipe.php
@@ -70,7 +70,18 @@ class ShapelessRecipe implements CraftingRecipe{
 	}
 
 	public function getResultsFor(CraftingGrid $grid) : array{
-		return $this->getResults();
+		$results = $this->getResults();
+
+		foreach($grid->getContents() as $inputItem){
+			if($inputItem->hasCustomBlockData()){
+				foreach($results as $result){
+					$result->setCustomBlockData($inputItem->getCustomBlockData());
+				}
+				break;
+			}
+		}
+
+		return $results;
 	}
 
 	public function getType() : ShapelessRecipeType{

--- a/src/inventory/transaction/CraftingTransaction.php
+++ b/src/inventory/transaction/CraftingTransaction.php
@@ -27,6 +27,7 @@ namespace pocketmine\inventory\transaction;
 
 use pocketmine\crafting\CraftingManager;
 use pocketmine\crafting\CraftingRecipe;
+use pocketmine\crafting\CraftingResultTransfer;
 use pocketmine\crafting\RecipeIngredient;
 use pocketmine\event\inventory\CraftItemEvent;
 use pocketmine\item\Item;
@@ -244,9 +245,20 @@ class CraftingTransaction extends InventoryTransaction{
 		return $iterations;
 	}
 
+	/**
+	 * @return Item[]
+	 * @phpstan-return list<Item>
+	 */
+	private function getExpectedResultsFor(CraftingRecipe $recipe) : array{
+		//grid may already be empty by validate() time - use transaction inputs as a fallback
+		$results = $recipe->getResultsFor($this->source->getCraftingGrid());
+		CraftingResultTransfer::transferContainerNamedTag($this->inputs, $results);
+		return $results;
+	}
+
 	private function validateRecipe(CraftingRecipe $recipe, ?int $expectedRepetitions) : int{
 		//compute number of times recipe was crafted
-		$repetitions = $this->matchOutputs($this->outputs, $recipe->getResultsFor($this->source->getCraftingGrid()));
+		$repetitions = $this->matchOutputs($this->outputs, $this->getExpectedResultsFor($recipe));
 		if($expectedRepetitions !== null && $repetitions !== $expectedRepetitions){
 			throw new TransactionValidationException("Expected $expectedRepetitions repetitions, got $repetitions");
 		}
@@ -269,7 +281,7 @@ class CraftingTransaction extends InventoryTransaction{
 			foreach($this->craftingManager->matchRecipeByOutputs($this->outputs) as $recipe){
 				try{
 					//compute number of times recipe was crafted
-					$this->repetitions = $this->matchOutputs($this->outputs, $recipe->getResultsFor($this->source->getCraftingGrid()));
+					$this->repetitions = $this->matchOutputs($this->outputs, $this->getExpectedResultsFor($recipe));
 					//assert that $repetitions x recipe ingredients should be consumed
 					self::matchIngredients($this->inputs, $recipe->getIngredientList(), $this->repetitions);
 

--- a/src/network/mcpe/InventoryManager.php
+++ b/src/network/mcpe/InventoryManager.php
@@ -36,10 +36,12 @@ use pocketmine\block\inventory\HopperInventory;
 use pocketmine\block\inventory\LoomInventory;
 use pocketmine\block\inventory\SmithingTableInventory;
 use pocketmine\block\inventory\StonecutterInventory;
+use pocketmine\block\tile\Container;
 use pocketmine\crafting\FurnaceType;
 use pocketmine\data\bedrock\EnchantmentIdMap;
 use pocketmine\inventory\Inventory;
 use pocketmine\inventory\transaction\action\SlotChangeAction;
+use pocketmine\inventory\transaction\CraftingTransaction;
 use pocketmine\inventory\transaction\InventoryTransaction;
 use pocketmine\item\enchantment\EnchantingOption;
 use pocketmine\item\enchantment\EnchantmentInstance;
@@ -252,6 +254,14 @@ class InventoryManager{
 	public function addTransactionPredictedSlotChanges(InventoryTransaction $tx) : void{
 		foreach($tx->getActions() as $action){
 			if($action instanceof SlotChangeAction){
+				//Don't predict crafting outputs that carry container NBT (e.g. dyed shulkers).
+				//The client predicts the plain recipe result; ItemStackResponse doesn't send full NBT
+				if(
+					$tx instanceof CraftingTransaction &&
+					$action->getTargetItem()->getNamedTag()->getTag(Container::TAG_ITEMS) !== null
+				){
+					continue;
+				}
 				//TODO: ItemStackRequestExecutor can probably build these predictions with much lower overhead
 				$this->addPredictedSlotChange(
 					$action->getInventory(),

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -58,7 +58,7 @@ use pocketmine\network\mcpe\protocol\types\recipe\NameItemDescriptor;
 use pocketmine\network\mcpe\protocol\types\recipe\RecipeIngredient as ProtocolRecipeIngredient;
 use pocketmine\network\mcpe\protocol\types\recipe\TagItemDescriptor;
 use pocketmine\player\GameMode;
-use pocketmine\utils\AssumptionFailedError;
+
 use pocketmine\utils\Filesystem;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\world\format\io\GlobalBlockStateHandlers;
@@ -157,12 +157,6 @@ class TypeConverter{
 		}elseif($ingredient instanceof ExactRecipeIngredient){
 			$item = $ingredient->getItem();
 			[$id, $meta, $blockRuntimeId] = $this->itemTranslator->toNetworkId($item);
-			if($blockRuntimeId !== null){
-				$meta = $this->blockTranslator->getBlockStateDictionary()->getMetaFromStateId($blockRuntimeId);
-				if($meta === null){
-					throw new AssumptionFailedError("Every block state should have an associated meta value");
-				}
-			}
 			$descriptor = new NameItemDescriptor($this->itemTypeDictionary->fromIntId($id), $meta);
 		}elseif($ingredient instanceof TagWildcardRecipeIngredient){
 			$descriptor = new TagItemDescriptor($ingredient->getTagName());

--- a/src/network/mcpe/convert/TypeConverter.php
+++ b/src/network/mcpe/convert/TypeConverter.php
@@ -58,7 +58,6 @@ use pocketmine\network\mcpe\protocol\types\recipe\NameItemDescriptor;
 use pocketmine\network\mcpe\protocol\types\recipe\RecipeIngredient as ProtocolRecipeIngredient;
 use pocketmine\network\mcpe\protocol\types\recipe\TagItemDescriptor;
 use pocketmine\player\GameMode;
-
 use pocketmine\utils\Filesystem;
 use pocketmine\utils\SingletonTrait;
 use pocketmine\world\format\io\GlobalBlockStateHandlers;
@@ -156,7 +155,9 @@ class TypeConverter{
 			$descriptor = new NameItemDescriptor($ingredient->getItemId(), self::RECIPE_INPUT_WILDCARD_META);
 		}elseif($ingredient instanceof ExactRecipeIngredient){
 			$item = $ingredient->getItem();
-			[$id, $meta, $blockRuntimeId] = $this->itemTranslator->toNetworkId($item);
+			[$id, $meta] = $this->itemTranslator->toNetworkId($item);
+			//Intentionally use item meta (0 for blockitems). Substituting network blockstate meta via
+			//getMetaFromStateId() makes the 1.26.40+ client drop the recipes from the recipe book.
 			$descriptor = new NameItemDescriptor($this->itemTypeDictionary->fromIntId($id), $meta);
 		}elseif($ingredient instanceof TagWildcardRecipeIngredient){
 			$descriptor = new TagItemDescriptor($ingredient->getTagName());

--- a/src/network/mcpe/handler/ItemStackRequestExecutor.php
+++ b/src/network/mcpe/handler/ItemStackRequestExecutor.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace pocketmine\network\mcpe\handler;
 
 use pocketmine\block\inventory\EnchantInventory;
+use pocketmine\crafting\CraftingResultTransfer;
 use pocketmine\inventory\Inventory;
 use pocketmine\inventory\transaction\action\CreateItemAction;
 use pocketmine\inventory\transaction\action\DestroyItemAction;
@@ -249,10 +250,8 @@ class ItemStackRequestExecutor{
 
 		$this->specialTransaction = new CraftingTransaction($this->player, $craftingManager, [], $recipe, $repetitions);
 
-		//TODO: Since the system assumes that crafting can only be done in the crafting grid, we have to give it a
-		//crafting grid to make the API happy. No implementation of getResultsFor() actually uses the crafting grid
-		//right now, so this will work, but this will become a problem in the future for things like shulker boxes and
-		//custom crafting recipes.
+		//CraftRecipeAuto may leave the crafting grid empty; container NBT is copied when
+		//CraftingConsumeInput is handled below (needed for shulker box dyeing etc.)
 		$craftingResults = $recipe->getResultsFor($this->player->getCraftingGrid());
 		foreach($craftingResults as $k => $craftingResult){
 			$craftingResult->setCount($craftingResult->getCount() * $repetitions);
@@ -357,8 +356,9 @@ class ItemStackRequestExecutor{
 			$this->beginCrafting($action->getRecipeId(), $action->getRepetitions());
 		}elseif($action instanceof CraftingConsumeInputStackRequestAction){
 			$this->assertDoingCrafting();
-			$this->removeItemFromSlot($action->getSource(), $action->getCount()); //output discarded - we allow CraftingTransaction to verify the balance
-
+			$consumed = $this->removeItemFromSlot($action->getSource(), $action->getCount());
+			//e.g. keep shulker box contents when dyeing
+			CraftingResultTransfer::transferContainerNamedTag([$consumed], $this->craftingResults);
 		}elseif($action instanceof CraftingCreateSpecificResultStackRequestAction){
 			$this->assertDoingCrafting();
 


### PR DESCRIPTION
## Summary
- Fix recipe book / crafting data issues on Bedrock **1.26.40+**: keep item meta from `toNetworkId()` for blockitem recipe ingredients (do **not** substitute network blockstate meta via `getMetaFromStateId()`), and fall back to a default blockstate when deserializing blockitems that have no meta-0 entry in the metamap (`lookupDefaultStateIdFromId`).
- Preserve shulker box contents (and related named-tag data) when dyeing in the crafting table. Shulker inventory lives under the root `Items` tag, not `BlockEntityTag`, so a dedicated `CraftingResultTransfer` copies that NBT from inputs onto results.
- Wire the transfer through `ShapedRecipe` / `ShapelessRecipe` `getResultsFor()`, `CraftingTransaction` validation (grid may already be empty), and `ItemStackRequestExecutor` on `CraftingConsumeInput` (needed for `CraftRecipeAuto`).