### PR TITLE
fix: PlayerItemUseEvent firing twice on right-click

### DIFF
--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -148,10 +148,14 @@ class InGamePacketHandler extends PacketHandler{
 	//prevent rejected edits while still mitigating book-bomb attacks
 	private const PAGE_LENGTH_SOFT_LIMIT_CHARS = 512;
 
+	private const RIGHT_CLICK_ITEM_USE_DEDUP_TICKS = 2;
+
 	protected float $lastRightClickTime = 0.0;
 	protected ?UseItemTransactionData $lastRightClickData = null;
 
 	private int $lastEarlyConsumableReleaseTick = -1000;
+
+	private int $lastTransactionRightClickItemUseTick = -1000;
 
 	protected ?Vector3 $lastPlayerAuthInputPosition = null;
 	protected ?float $lastPlayerAuthInputYaw = null;
@@ -228,10 +232,6 @@ class InGamePacketHandler extends PacketHandler{
 			$this->forceMoveSync = false;
 		}
 
-		$useItemTransaction = $packet->getItemInteractionData();
-		$rightClickItemUseHandledByTransaction = $useItemTransaction !== null
-			&& self::transactionTriggersRightClickItemUse($useItemTransaction->getTransactionData());
-
 		$inputFlags = $packet->getInputFlags();
 		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
@@ -259,7 +259,7 @@ class InGamePacketHandler extends PacketHandler{
 			if($inputFlags->get(PlayerAuthInputFlags::START_USING_ITEM)){
 				if(!$this->player->shouldIgnoreChargeableClickAir()){
 					$this->player->clearAwaitingConsumableRelease();
-					if(!$rightClickItemUseHandledByTransaction){
+					if(!$this->recentlyUsedItemViaTransaction()){
 						$this->handleRightClickItemUse();
 					}
 				}
@@ -277,6 +277,7 @@ class InGamePacketHandler extends PacketHandler{
 
 		$packetHandled = true;
 
+		$useItemTransaction = $packet->getItemInteractionData();
 		if($useItemTransaction !== null){
 			if(count($useItemTransaction->getTransactionData()->getActions()) > 100){
 				throw new PacketHandlingException("Too many actions in item use transaction");
@@ -500,6 +501,10 @@ class InGamePacketHandler extends PacketHandler{
 	private function handleUseItemTransaction(UseItemTransactionData $data) : bool{
 		$this->player->selectHotbarSlot($data->getHotbarSlot());
 
+		if(self::transactionTriggersRightClickItemUse($data)){
+			$this->lastTransactionRightClickItemUseTick = $this->player->getServer()->getTick();
+		}
+
 		switch($data->getActionType()){
 			case UseItemTransactionData::ACTION_CLICK_BLOCK:
 				//TODO: start hack for client spam bug
@@ -576,6 +581,10 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		return false;
+	}
+
+	private function recentlyUsedItemViaTransaction() : bool{
+		return $this->player->getServer()->getTick() - $this->lastTransactionRightClickItemUseTick <= self::RIGHT_CLICK_ITEM_USE_DEDUP_TICKS;
 	}
 
 	private static function transactionTriggersRightClickItemUse(UseItemTransactionData $data) : bool{

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -228,6 +228,14 @@ class InGamePacketHandler extends PacketHandler{
 			$this->forceMoveSync = false;
 		}
 
+		//A single PlayerAuthInputPacket can carry both the START_USING_ITEM flag AND item interaction data
+		//(e.g. ACTION_CLICK_AIR) representing the SAME physical right-click. If both are handled independently,
+		//handleRightClickItemUse() ends up being called twice for one click. Detect this ahead of time so the
+		//flag-driven call below can be skipped when the transaction below will already handle it.
+		$useItemTransactionForDedup = $packet->getItemInteractionData();
+		$willHandleClickAirViaTransaction = $useItemTransactionForDedup !== null
+			&& $useItemTransactionForDedup->getTransactionData()->getActionType() === UseItemTransactionData::ACTION_CLICK_AIR;
+
 		$inputFlags = $packet->getInputFlags();
 		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
 			$this->lastPlayerAuthInputFlags = $inputFlags;
@@ -253,7 +261,7 @@ class InGamePacketHandler extends PacketHandler{
 				$this->player->jump();
 			}
 			if($inputFlags->get(PlayerAuthInputFlags::START_USING_ITEM)){
-				if(!$this->player->shouldIgnoreChargeableClickAir()){
+				if(!$this->player->shouldIgnoreChargeableClickAir() && !$willHandleClickAirViaTransaction){
 					$this->player->clearAwaitingConsumableRelease();
 					$this->handleRightClickItemUse();
 				}

--- a/src/network/mcpe/handler/InGamePacketHandler.php
+++ b/src/network/mcpe/handler/InGamePacketHandler.php
@@ -228,13 +228,9 @@ class InGamePacketHandler extends PacketHandler{
 			$this->forceMoveSync = false;
 		}
 
-		//A single PlayerAuthInputPacket can carry both the START_USING_ITEM flag AND item interaction data
-		//(e.g. ACTION_CLICK_AIR) representing the SAME physical right-click. If both are handled independently,
-		//handleRightClickItemUse() ends up being called twice for one click. Detect this ahead of time so the
-		//flag-driven call below can be skipped when the transaction below will already handle it.
-		$useItemTransactionForDedup = $packet->getItemInteractionData();
-		$willHandleClickAirViaTransaction = $useItemTransactionForDedup !== null
-			&& $useItemTransactionForDedup->getTransactionData()->getActionType() === UseItemTransactionData::ACTION_CLICK_AIR;
+		$useItemTransaction = $packet->getItemInteractionData();
+		$rightClickItemUseHandledByTransaction = $useItemTransaction !== null
+			&& self::transactionTriggersRightClickItemUse($useItemTransaction->getTransactionData());
 
 		$inputFlags = $packet->getInputFlags();
 		if($this->lastPlayerAuthInputFlags === null || !$inputFlags->equals($this->lastPlayerAuthInputFlags)){
@@ -261,9 +257,11 @@ class InGamePacketHandler extends PacketHandler{
 				$this->player->jump();
 			}
 			if($inputFlags->get(PlayerAuthInputFlags::START_USING_ITEM)){
-				if(!$this->player->shouldIgnoreChargeableClickAir() && !$willHandleClickAirViaTransaction){
+				if(!$this->player->shouldIgnoreChargeableClickAir()){
 					$this->player->clearAwaitingConsumableRelease();
-					$this->handleRightClickItemUse();
+					if(!$rightClickItemUseHandledByTransaction){
+						$this->handleRightClickItemUse();
+					}
 				}
 			}
 			if($inputFlags->get(PlayerAuthInputFlags::MISSED_SWING)){
@@ -279,7 +277,6 @@ class InGamePacketHandler extends PacketHandler{
 
 		$packetHandled = true;
 
-		$useItemTransaction = $packet->getItemInteractionData();
 		if($useItemTransaction !== null){
 			if(count($useItemTransaction->getTransactionData()->getActions()) > 100){
 				throw new PacketHandlingException("Too many actions in item use transaction");
@@ -579,6 +576,14 @@ class InGamePacketHandler extends PacketHandler{
 		}
 
 		return false;
+	}
+
+	private static function transactionTriggersRightClickItemUse(UseItemTransactionData $data) : bool{
+		return match($data->getActionType()){
+			UseItemTransactionData::ACTION_CLICK_AIR => true,
+			UseItemTransactionData::ACTION_BREAK_BLOCK => $data->getFace() === 255,
+			default => false,
+		};
 	}
 
 	/**


### PR DESCRIPTION
Fixes #28

## Changes
Found the bug - handleRightClickItemUse() gets called twice for one 
right-click. This happens because START_USING_ITEM flag triggers it once, 
and then itemInteractionData (ACTION_CLICK_AIR) triggers it again, both 
from the same PlayerAuthInputPacket. Added a check so it only fires once 
now.

## Tests
Tested with a test plugin that spawns something on PlayerItemUseEvent. 
Before the fix it spawned twice per click, now it only spawns once.