### PR TITLE
feat: implemented spear and lunge enchantment

### DIFF
--- a/generated/item/VanillaItems.php
+++ b/generated/item/VanillaItems.php
@@ -142,6 +142,7 @@ final class VanillaItems{
 	private static Item $_mCOPPER_NUGGET;
 	private static Pickaxe $_mCOPPER_PICKAXE;
 	private static Shovel $_mCOPPER_SHOVEL;
+	private static Spear $_mCOPPER_SPEAR;
 	private static Sword $_mCOPPER_SWORD;
 	private static CoralFan $_mCORAL_FAN;
 	private static HangingSign $_mCRIMSON_HANGING_SIGN;
@@ -158,6 +159,7 @@ final class VanillaItems{
 	private static Armor $_mDIAMOND_LEGGINGS;
 	private static Pickaxe $_mDIAMOND_PICKAXE;
 	private static Shovel $_mDIAMOND_SHOVEL;
+	private static Spear $_mDIAMOND_SPEAR;
 	private static Sword $_mDIAMOND_SWORD;
 	private static Item $_mDISC_FRAGMENT_5;
 	private static Item $_mDRAGON_BREATH;
@@ -199,6 +201,7 @@ final class VanillaItems{
 	private static Armor $_mGOLDEN_LEGGINGS;
 	private static Pickaxe $_mGOLDEN_PICKAXE;
 	private static Shovel $_mGOLDEN_SHOVEL;
+	private static Spear $_mGOLDEN_SPEAR;
 	private static Sword $_mGOLDEN_SWORD;
 	private static Item $_mGOLD_INGOT;
 	private static Item $_mGOLD_NUGGET;
@@ -219,6 +222,7 @@ final class VanillaItems{
 	private static Item $_mIRON_NUGGET;
 	private static Pickaxe $_mIRON_PICKAXE;
 	private static Shovel $_mIRON_SHOVEL;
+	private static Spear $_mIRON_SPEAR;
 	private static Sword $_mIRON_SWORD;
 	private static Boat $_mJUNGLE_BOAT;
 	private static HangingSign $_mJUNGLE_HANGING_SIGN;
@@ -253,6 +257,7 @@ final class VanillaItems{
 	private static Pickaxe $_mNETHERITE_PICKAXE;
 	private static Item $_mNETHERITE_SCRAP;
 	private static Shovel $_mNETHERITE_SHOVEL;
+	private static Spear $_mNETHERITE_SPEAR;
 	private static Sword $_mNETHERITE_SWORD;
 	private static Item $_mNETHERITE_UPGRADE_SMITHING_TEMPLATE;
 	private static Item $_mNETHER_BRICK;
@@ -342,6 +347,7 @@ final class VanillaItems{
 	private static Hoe $_mSTONE_HOE;
 	private static Pickaxe $_mSTONE_PICKAXE;
 	private static Shovel $_mSTONE_SHOVEL;
+	private static Spear $_mSTONE_SPEAR;
 	private static Sword $_mSTONE_SWORD;
 	private static StringItem $_mSTRING;
 	private static Item $_mSUGAR;
@@ -368,6 +374,7 @@ final class VanillaItems{
 	private static Hoe $_mWOODEN_HOE;
 	private static Pickaxe $_mWOODEN_PICKAXE;
 	private static Shovel $_mWOODEN_SHOVEL;
+	private static Spear $_mWOODEN_SPEAR;
 	private static Sword $_mWOODEN_SWORD;
 	private static WritableBook $_mWRITABLE_BOOK;
 	private static WrittenBook $_mWRITTEN_BOOK;
@@ -508,6 +515,7 @@ final class VanillaItems{
 			"copper_nugget" => fn(Item $v) => self::$_mCOPPER_NUGGET = $v,
 			"copper_pickaxe" => fn(Pickaxe $v) => self::$_mCOPPER_PICKAXE = $v,
 			"copper_shovel" => fn(Shovel $v) => self::$_mCOPPER_SHOVEL = $v,
+			"copper_spear" => fn(Spear $v) => self::$_mCOPPER_SPEAR = $v,
 			"copper_sword" => fn(Sword $v) => self::$_mCOPPER_SWORD = $v,
 			"coral_fan" => fn(CoralFan $v) => self::$_mCORAL_FAN = $v,
 			"crimson_hanging_sign" => fn(HangingSign $v) => self::$_mCRIMSON_HANGING_SIGN = $v,
@@ -524,6 +532,7 @@ final class VanillaItems{
 			"diamond_leggings" => fn(Armor $v) => self::$_mDIAMOND_LEGGINGS = $v,
 			"diamond_pickaxe" => fn(Pickaxe $v) => self::$_mDIAMOND_PICKAXE = $v,
 			"diamond_shovel" => fn(Shovel $v) => self::$_mDIAMOND_SHOVEL = $v,
+			"diamond_spear" => fn(Spear $v) => self::$_mDIAMOND_SPEAR = $v,
 			"diamond_sword" => fn(Sword $v) => self::$_mDIAMOND_SWORD = $v,
 			"disc_fragment_5" => fn(Item $v) => self::$_mDISC_FRAGMENT_5 = $v,
 			"dragon_breath" => fn(Item $v) => self::$_mDRAGON_BREATH = $v,
@@ -565,6 +574,7 @@ final class VanillaItems{
 			"golden_leggings" => fn(Armor $v) => self::$_mGOLDEN_LEGGINGS = $v,
 			"golden_pickaxe" => fn(Pickaxe $v) => self::$_mGOLDEN_PICKAXE = $v,
 			"golden_shovel" => fn(Shovel $v) => self::$_mGOLDEN_SHOVEL = $v,
+			"golden_spear" => fn(Spear $v) => self::$_mGOLDEN_SPEAR = $v,
 			"golden_sword" => fn(Sword $v) => self::$_mGOLDEN_SWORD = $v,
 			"gold_ingot" => fn(Item $v) => self::$_mGOLD_INGOT = $v,
 			"gold_nugget" => fn(Item $v) => self::$_mGOLD_NUGGET = $v,
@@ -585,6 +595,7 @@ final class VanillaItems{
 			"iron_nugget" => fn(Item $v) => self::$_mIRON_NUGGET = $v,
 			"iron_pickaxe" => fn(Pickaxe $v) => self::$_mIRON_PICKAXE = $v,
 			"iron_shovel" => fn(Shovel $v) => self::$_mIRON_SHOVEL = $v,
+			"iron_spear" => fn(Spear $v) => self::$_mIRON_SPEAR = $v,
 			"iron_sword" => fn(Sword $v) => self::$_mIRON_SWORD = $v,
 			"jungle_boat" => fn(Boat $v) => self::$_mJUNGLE_BOAT = $v,
 			"jungle_hanging_sign" => fn(HangingSign $v) => self::$_mJUNGLE_HANGING_SIGN = $v,
@@ -619,6 +630,7 @@ final class VanillaItems{
 			"netherite_pickaxe" => fn(Pickaxe $v) => self::$_mNETHERITE_PICKAXE = $v,
 			"netherite_scrap" => fn(Item $v) => self::$_mNETHERITE_SCRAP = $v,
 			"netherite_shovel" => fn(Shovel $v) => self::$_mNETHERITE_SHOVEL = $v,
+			"netherite_spear" => fn(Spear $v) => self::$_mNETHERITE_SPEAR = $v,
 			"netherite_sword" => fn(Sword $v) => self::$_mNETHERITE_SWORD = $v,
 			"netherite_upgrade_smithing_template" => fn(Item $v) => self::$_mNETHERITE_UPGRADE_SMITHING_TEMPLATE = $v,
 			"nether_brick" => fn(Item $v) => self::$_mNETHER_BRICK = $v,
@@ -708,6 +720,7 @@ final class VanillaItems{
 			"stone_hoe" => fn(Hoe $v) => self::$_mSTONE_HOE = $v,
 			"stone_pickaxe" => fn(Pickaxe $v) => self::$_mSTONE_PICKAXE = $v,
 			"stone_shovel" => fn(Shovel $v) => self::$_mSTONE_SHOVEL = $v,
+			"stone_spear" => fn(Spear $v) => self::$_mSTONE_SPEAR = $v,
 			"stone_sword" => fn(Sword $v) => self::$_mSTONE_SWORD = $v,
 			"string" => fn(StringItem $v) => self::$_mSTRING = $v,
 			"sugar" => fn(Item $v) => self::$_mSUGAR = $v,
@@ -734,6 +747,7 @@ final class VanillaItems{
 			"wooden_hoe" => fn(Hoe $v) => self::$_mWOODEN_HOE = $v,
 			"wooden_pickaxe" => fn(Pickaxe $v) => self::$_mWOODEN_PICKAXE = $v,
 			"wooden_shovel" => fn(Shovel $v) => self::$_mWOODEN_SHOVEL = $v,
+			"wooden_spear" => fn(Spear $v) => self::$_mWOODEN_SPEAR = $v,
 			"wooden_sword" => fn(Sword $v) => self::$_mWOODEN_SWORD = $v,
 			"writable_book" => fn(WritableBook $v) => self::$_mWRITABLE_BOOK = $v,
 			"written_book" => fn(WrittenBook $v) => self::$_mWRITTEN_BOOK = $v,
@@ -1286,6 +1300,11 @@ final class VanillaItems{
 		return clone self::$_mCOPPER_SHOVEL;
 	}
 
+	public static function COPPER_SPEAR() : Spear{
+		if(!isset(self::$_mCOPPER_SPEAR)){ self::init(); }
+		return clone self::$_mCOPPER_SPEAR;
+	}
+
 	public static function COPPER_SWORD() : Sword{
 		if(!isset(self::$_mCOPPER_SWORD)){ self::init(); }
 		return clone self::$_mCOPPER_SWORD;
@@ -1364,6 +1383,11 @@ final class VanillaItems{
 	public static function DIAMOND_SHOVEL() : Shovel{
 		if(!isset(self::$_mDIAMOND_SHOVEL)){ self::init(); }
 		return clone self::$_mDIAMOND_SHOVEL;
+	}
+
+	public static function DIAMOND_SPEAR() : Spear{
+		if(!isset(self::$_mDIAMOND_SPEAR)){ self::init(); }
+		return clone self::$_mDIAMOND_SPEAR;
 	}
 
 	public static function DIAMOND_SWORD() : Sword{
@@ -1571,6 +1595,11 @@ final class VanillaItems{
 		return clone self::$_mGOLDEN_SHOVEL;
 	}
 
+	public static function GOLDEN_SPEAR() : Spear{
+		if(!isset(self::$_mGOLDEN_SPEAR)){ self::init(); }
+		return clone self::$_mGOLDEN_SPEAR;
+	}
+
 	public static function GOLDEN_SWORD() : Sword{
 		if(!isset(self::$_mGOLDEN_SWORD)){ self::init(); }
 		return clone self::$_mGOLDEN_SWORD;
@@ -1669,6 +1698,11 @@ final class VanillaItems{
 	public static function IRON_SHOVEL() : Shovel{
 		if(!isset(self::$_mIRON_SHOVEL)){ self::init(); }
 		return clone self::$_mIRON_SHOVEL;
+	}
+
+	public static function IRON_SPEAR() : Spear{
+		if(!isset(self::$_mIRON_SPEAR)){ self::init(); }
+		return clone self::$_mIRON_SPEAR;
 	}
 
 	public static function IRON_SWORD() : Sword{
@@ -1839,6 +1873,11 @@ final class VanillaItems{
 	public static function NETHERITE_SHOVEL() : Shovel{
 		if(!isset(self::$_mNETHERITE_SHOVEL)){ self::init(); }
 		return clone self::$_mNETHERITE_SHOVEL;
+	}
+
+	public static function NETHERITE_SPEAR() : Spear{
+		if(!isset(self::$_mNETHERITE_SPEAR)){ self::init(); }
+		return clone self::$_mNETHERITE_SPEAR;
 	}
 
 	public static function NETHERITE_SWORD() : Sword{
@@ -2286,6 +2325,11 @@ final class VanillaItems{
 		return clone self::$_mSTONE_SHOVEL;
 	}
 
+	public static function STONE_SPEAR() : Spear{
+		if(!isset(self::$_mSTONE_SPEAR)){ self::init(); }
+		return clone self::$_mSTONE_SPEAR;
+	}
+
 	public static function STONE_SWORD() : Sword{
 		if(!isset(self::$_mSTONE_SWORD)){ self::init(); }
 		return clone self::$_mSTONE_SWORD;
@@ -2414,6 +2458,11 @@ final class VanillaItems{
 	public static function WOODEN_SHOVEL() : Shovel{
 		if(!isset(self::$_mWOODEN_SHOVEL)){ self::init(); }
 		return clone self::$_mWOODEN_SHOVEL;
+	}
+
+	public static function WOODEN_SPEAR() : Spear{
+		if(!isset(self::$_mWOODEN_SPEAR)){ self::init(); }
+		return clone self::$_mWOODEN_SPEAR;
 	}
 
 	public static function WOODEN_SWORD() : Sword{

--- a/generated/item/enchantment/VanillaEnchantments.php
+++ b/generated/item/enchantment/VanillaEnchantments.php
@@ -49,6 +49,7 @@ final class VanillaEnchantments{
 	private static Enchantment $_mFROST_WALKER;
 	private static Enchantment $_mINFINITY;
 	private static KnockbackEnchantment $_mKNOCKBACK;
+	private static Enchantment $_mLUNGE;
 	private static Enchantment $_mMENDING;
 	private static Enchantment $_mPOWER;
 	private static ProtectionEnchantment $_mPROJECTILE_PROTECTION;
@@ -106,6 +107,7 @@ final class VanillaEnchantments{
 			"FROST_WALKER" => fn(Enchantment $v) => self::$_mFROST_WALKER = $v,
 			"INFINITY" => fn(Enchantment $v) => self::$_mINFINITY = $v,
 			"KNOCKBACK" => fn(KnockbackEnchantment $v) => self::$_mKNOCKBACK = $v,
+			"LUNGE" => fn(Enchantment $v) => self::$_mLUNGE = $v,
 			"MENDING" => fn(Enchantment $v) => self::$_mMENDING = $v,
 			"POWER" => fn(Enchantment $v) => self::$_mPOWER = $v,
 			"PROJECTILE_PROTECTION" => fn(ProtectionEnchantment $v) => self::$_mPROJECTILE_PROTECTION = $v,
@@ -209,6 +211,11 @@ final class VanillaEnchantments{
 	public static function KNOCKBACK() : KnockbackEnchantment{
 		if(!isset(self::$_mKNOCKBACK)){ self::init(); }
 		return self::$_mKNOCKBACK;
+	}
+
+	public static function LUNGE() : Enchantment{
+		if(!isset(self::$_mLUNGE)){ self::init(); }
+		return self::$_mLUNGE;
 	}
 
 	public static function MENDING() : Enchantment{

--- a/src/data/bedrock/EnchantmentIdMap.php
+++ b/src/data/bedrock/EnchantmentIdMap.php
@@ -70,5 +70,7 @@ final class EnchantmentIdMap{
 		$this->register(EnchantmentIds::SWIFT_SNEAK, VanillaEnchantments::SWIFT_SNEAK());
 
 		$this->register(EnchantmentIds::FROST_WALKER, VanillaEnchantments::FROST_WALKER());
+
+		$this->register(EnchantmentIds::LUNGE, VanillaEnchantments::LUNGE());
 	}
 }

--- a/src/data/bedrock/EnchantmentIds.php
+++ b/src/data/bedrock/EnchantmentIds.php
@@ -69,4 +69,5 @@ final class EnchantmentIds{
 	public const QUICK_CHARGE = 35;
 	public const SOUL_SPEED = 36;
 	public const SWIFT_SNEAK = 37;
+	public const LUNGE = 41;
 }

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -236,6 +236,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::COPPER_NUGGET, Items::COPPER_NUGGET());
 		$this->map1to1Item(Ids::COPPER_PICKAXE, Items::COPPER_PICKAXE());
 		$this->map1to1Item(Ids::COPPER_SHOVEL, Items::COPPER_SHOVEL());
+		$this->map1to1Item(Ids::COPPER_SPEAR, Items::COPPER_SPEAR());
 		$this->map1to1Item(Ids::COPPER_SWORD, Items::COPPER_SWORD());
 		$this->map1to1Item(Ids::CRIMSON_HANGING_SIGN, Items::CRIMSON_HANGING_SIGN());
 		$this->map1to1Item(Ids::CRIMSON_SIGN, Items::CRIMSON_SIGN());
@@ -251,6 +252,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::DIAMOND_LEGGINGS, Items::DIAMOND_LEGGINGS());
 		$this->map1to1Item(Ids::DIAMOND_PICKAXE, Items::DIAMOND_PICKAXE());
 		$this->map1to1Item(Ids::DIAMOND_SHOVEL, Items::DIAMOND_SHOVEL());
+		$this->map1to1Item(Ids::DIAMOND_SPEAR, Items::DIAMOND_SPEAR());
 		$this->map1to1Item(Ids::DIAMOND_SWORD, Items::DIAMOND_SWORD());
 		$this->map1to1Item(Ids::DISC_FRAGMENT_5, Items::DISC_FRAGMENT_5());
 		$this->map1to1Item(Ids::DRAGON_BREATH, Items::DRAGON_BREATH());
@@ -291,6 +293,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::GOLDEN_LEGGINGS, Items::GOLDEN_LEGGINGS());
 		$this->map1to1Item(Ids::GOLDEN_PICKAXE, Items::GOLDEN_PICKAXE());
 		$this->map1to1Item(Ids::GOLDEN_SHOVEL, Items::GOLDEN_SHOVEL());
+		$this->map1to1Item(Ids::GOLDEN_SPEAR, Items::GOLDEN_SPEAR());
 		$this->map1to1Item(Ids::GOLDEN_SWORD, Items::GOLDEN_SWORD());
 		$this->map1to1Item(Ids::GUNPOWDER, Items::GUNPOWDER());
 		$this->map1to1Item(Ids::HEART_OF_THE_SEA, Items::HEART_OF_THE_SEA());
@@ -309,6 +312,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::IRON_NUGGET, Items::IRON_NUGGET());
 		$this->map1to1Item(Ids::IRON_PICKAXE, Items::IRON_PICKAXE());
 		$this->map1to1Item(Ids::IRON_SHOVEL, Items::IRON_SHOVEL());
+		$this->map1to1Item(Ids::IRON_SPEAR, Items::IRON_SPEAR());
 		$this->map1to1Item(Ids::IRON_SWORD, Items::IRON_SWORD());
 		$this->map1to1Item(Ids::JUNGLE_BOAT, Items::JUNGLE_BOAT());
 		$this->map1to1Item(Ids::JUNGLE_HANGING_SIGN, Items::JUNGLE_HANGING_SIGN());
@@ -365,6 +369,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::NETHERITE_PICKAXE, Items::NETHERITE_PICKAXE());
 		$this->map1to1Item(Ids::NETHERITE_SCRAP, Items::NETHERITE_SCRAP());
 		$this->map1to1Item(Ids::NETHERITE_SHOVEL, Items::NETHERITE_SHOVEL());
+		$this->map1to1Item(Ids::NETHERITE_SPEAR, Items::NETHERITE_SPEAR());
 		$this->map1to1Item(Ids::NETHERITE_SWORD, Items::NETHERITE_SWORD());
 		$this->map1to1Item(Ids::NETHERITE_UPGRADE_SMITHING_TEMPLATE, Items::NETHERITE_UPGRADE_SMITHING_TEMPLATE());
 		$this->map1to1Item(Ids::OAK_BOAT, Items::OAK_BOAT());
@@ -422,6 +427,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::STONE_HOE, Items::STONE_HOE());
 		$this->map1to1Item(Ids::STONE_PICKAXE, Items::STONE_PICKAXE());
 		$this->map1to1Item(Ids::STONE_SHOVEL, Items::STONE_SHOVEL());
+		$this->map1to1Item(Ids::STONE_SPEAR, Items::STONE_SPEAR());
 		$this->map1to1Item(Ids::STONE_SWORD, Items::STONE_SWORD());
 		$this->map1to1Item(Ids::STRING, Items::STRING());
 		$this->map1to1Item(Ids::SUGAR, Items::SUGAR());
@@ -448,6 +454,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::WOODEN_HOE, Items::WOODEN_HOE());
 		$this->map1to1Item(Ids::WOODEN_PICKAXE, Items::WOODEN_PICKAXE());
 		$this->map1to1Item(Ids::WOODEN_SHOVEL, Items::WOODEN_SHOVEL());
+		$this->map1to1Item(Ids::WOODEN_SPEAR, Items::WOODEN_SPEAR());
 		$this->map1to1Item(Ids::WOODEN_SWORD, Items::WOODEN_SWORD());
 		$this->map1to1Item(Ids::WRITABLE_BOOK, Items::WRITABLE_BOOK());
 		$this->map1to1Item(Ids::WRITTEN_BOOK, Items::WRITTEN_BOOK());

--- a/src/event/player/PlayerSpearStabEvent.php
+++ b/src/event/player/PlayerSpearStabEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\event\player;
+
+use pocketmine\event\Cancellable;
+use pocketmine\event\CancellableTrait;
+use pocketmine\item\Item;
+use pocketmine\player\Player;
+
+class PlayerSpearStabEvent extends PlayerEvent implements Cancellable{
+	use CancellableTrait;
+
+	public function __construct(
+		Player $player,
+		private Item $item,
+		private float $movementSpeed
+	){
+		$this->player = $player;
+	}
+
+	public function getItem() : Item{
+		return clone $this->item;
+	}
+
+	public function getMovementSpeed() : float{
+		return $this->movementSpeed;
+	}
+}

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -372,8 +372,15 @@ final class ItemTypeIds{
 	public const SHIELD = 20331;
 	public const ARMOR_STAND = 20332;
 	public const WOLF_ARMOR = 20333;
+	public const COPPER_SPEAR = 20334;
+	public const DIAMOND_SPEAR = 20335;
+	public const GOLDEN_SPEAR = 20336;
+	public const IRON_SPEAR = 20337;
+	public const NETHERITE_SPEAR = 20338;
+	public const STONE_SPEAR = 20339;
+	public const WOODEN_SPEAR = 20340;
 
-	public const FIRST_UNUSED_ITEM_ID = 20334;
+	public const FIRST_UNUSED_ITEM_ID = 20341;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_ITEM_ID;
 

--- a/src/item/Spear.php
+++ b/src/item/Spear.php
@@ -1,0 +1,325 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+use pocketmine\entity\Living;
+use pocketmine\event\entity\EntityDamageByEntityEvent;
+use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\event\player\PlayerExhaustEvent;
+use pocketmine\event\player\PlayerSpearStabEvent;
+use pocketmine\item\enchantment\VanillaEnchantments;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\sound\CopperSpearAttackHitSound;
+use pocketmine\world\sound\CopperSpearAttackMissSound;
+use pocketmine\world\sound\CopperSpearUseSound;
+use pocketmine\world\sound\DiamondSpearAttackHitSound;
+use pocketmine\world\sound\DiamondSpearAttackMissSound;
+use pocketmine\world\sound\DiamondSpearUseSound;
+use pocketmine\world\sound\GoldenSpearAttackHitSound;
+use pocketmine\world\sound\GoldenSpearAttackMissSound;
+use pocketmine\world\sound\GoldenSpearUseSound;
+use pocketmine\world\sound\IronSpearAttackHitSound;
+use pocketmine\world\sound\IronSpearAttackMissSound;
+use pocketmine\world\sound\IronSpearUseSound;
+use pocketmine\world\sound\NetheriteSpearAttackHitSound;
+use pocketmine\world\sound\NetheriteSpearAttackMissSound;
+use pocketmine\world\sound\NetheriteSpearUseSound;
+use pocketmine\world\sound\Sound;
+use pocketmine\world\sound\SpearLungeSound;
+use pocketmine\world\sound\StoneSpearAttackHitSound;
+use pocketmine\world\sound\StoneSpearAttackMissSound;
+use pocketmine\world\sound\StoneSpearUseSound;
+use pocketmine\world\sound\WoodenSpearAttackHitSound;
+use pocketmine\world\sound\WoodenSpearAttackMissSound;
+use pocketmine\world\sound\WoodenSpearUseSound;
+use function min;
+use const PHP_FLOAT_MAX;
+
+class Spear extends TieredTool implements Releasable{
+
+	/** Minimum movement speed required for a stab or a sweep to actually connect. */
+	public const MINIMUM_SPEED = 0.13;
+	/** Minimum food level required to lunge, in gamemodes with finite resources. */
+	public const MINIMUM_LUNGE_FOOD = 6;
+	/** Exhaustion applied per level of Lunge. */
+	public const BASE_LUNGE_EXHAUST = 4.0;
+	/** Cooldown applied to the item after a stab, in ticks. */
+	public const STAB_COOLDOWN_TICKS = 20;
+	/** How often (in ticks) the sweep check runs while the item is being held. */
+	public const SWEEP_INTERVAL_TICKS = 5;
+	/** Maximum reach of a stab, in blocks. */
+	public const MAX_STAB_DISTANCE = 5.0;
+
+	public function getAttackPoints() : int{
+		return $this->tier->getBaseAttackPoints();
+	}
+
+	public function getUsingTicks() : int{
+		return 72000;
+	}
+
+	public function getMinUseDuration() : int{
+		return 1;
+	}
+
+	public function canStartUsingItem(Player $player) : bool{
+		return !$this->isBroken();
+	}
+
+	public function onAttackEntity(Entity $victim, array &$returnedItems) : bool{
+		return $this->applyDamage(1);
+	}
+
+	public function onDestroyBlock(Block $block, array &$returnedItems) : bool{
+		if($block->getBreakInfo()->breaksInstantly()){
+			return false;
+		}
+
+		return $this->applyDamage(2);
+	}
+
+	public function onClickAir(Player $player, Vector3 $directionVector, array &$returnedItems) : ItemUseResult{
+		$player->getWorld()->addSound($player->getPosition(), $this->getUseSound());
+
+		return ItemUseResult::NONE;
+	}
+
+	/**
+	 * Called when the player releases the "use item" button, performing a stab in the direction they are looking.
+	 */
+	public function onReleaseUsing(Player $player, array &$returnedItems) : ItemUseResult{
+		if($player->hasItemCooldown($this)){
+			return ItemUseResult::FAIL;
+		}
+
+		$event = new PlayerSpearStabEvent($player, $this, $player->getMovementSpeed());
+		$event->call();
+		if($event->isCancelled()){
+			return ItemUseResult::FAIL;
+		}
+
+		$player->resetItemCooldown($this, self::STAB_COOLDOWN_TICKS);
+		$this->applyLunge($player);
+
+		if($player->getMovementSpeed() < self::MINIMUM_SPEED || !$player->isSprinting()){
+			$player->getWorld()->addSound($player->getPosition(), $this->getMissSound());
+
+			return ItemUseResult::SUCCESS;
+		}
+
+		$target = $this->findStabTarget($player);
+		if($target !== null){
+			$target->attack(new EntityDamageByEntityEvent(
+				$player,
+				$target,
+				EntityDamageEvent::CAUSE_ENTITY_ATTACK,
+				$this->getJabDamage()
+			));
+			$player->getWorld()->addSound($player->getPosition(), $this->getHitSound());
+		}else{
+			$player->getWorld()->addSound($player->getPosition(), $this->getMissSound());
+		}
+
+		$this->applyDamage(1);
+
+		return ItemUseResult::SUCCESS;
+	}
+
+	/**
+	 * Called every tick while the player holds the "use item" button, sweeping anything they charge into.
+	 */
+	public function whileSpearUsing(Player $player) : void{
+		if($player->getItemUseDuration() % self::SWEEP_INTERVAL_TICKS !== 0){
+			return;
+		}
+
+		$speed = $player->getMovementSpeed();
+		if($speed < self::MINIMUM_SPEED){
+			return;
+		}
+
+		$target = $this->findSweepTarget($player);
+		if($target === null){
+			return;
+		}
+
+		$target->attack(new EntityDamageByEntityEvent(
+			$player,
+			$target,
+			EntityDamageEvent::CAUSE_ENTITY_ATTACK,
+			$this->getAttackPoints() * 1.5 + ($speed * 3.0)
+		));
+		$player->getWorld()->addSound($player->getPosition(), $this->getHitSound());
+	}
+
+	/**
+	 * Returns the damage dealt by a stab, including the bonus granted by Lunge.
+	 */
+	public function getJabDamage() : float{
+		return $this->getAttackPoints() + ($this->getEnchantmentLevel(VanillaEnchantments::LUNGE()) * 1.5);
+	}
+
+	public function canLunge(Player $player) : bool{
+		if($this->getEnchantmentLevel(VanillaEnchantments::LUNGE()) <= 0){
+			return false;
+		}
+
+		if($player->isGliding() || $player->isSwimming() || $player->isUnderwater()){
+			return false;
+		}
+
+		return !$player->hasFiniteResources() || $player->getHungerManager()->getFood() >= self::MINIMUM_LUNGE_FOOD;
+	}
+
+	public function applyLunge(Player $player) : void{
+		if(!$this->canLunge($player)){
+			return;
+		}
+
+		$direction = $player->getDirectionVector()->withComponents(null, 0, null);
+		if($direction->lengthSquared() <= 0){
+			return;
+		}
+
+		$lungeLevel = $this->getEnchantmentLevel(VanillaEnchantments::LUNGE());
+		$push = $direction->normalize()->multiply(0.5 + ($lungeLevel * 0.4));
+
+		$player->setMotion($player->getMotion()->addVector($push));
+		$player->getWorld()->addSound($player->getPosition(), $this->getLungeSound($lungeLevel));
+		$player->getHungerManager()->exhaust(self::BASE_LUNGE_EXHAUST * $lungeLevel, PlayerExhaustEvent::CAUSE_ATTACK);
+	}
+
+	/**
+	 * Finds the best living entity inside the cone the player is looking at.
+	 */
+	private function findStabTarget(Player $player) : ?Living{
+		$eyePos = $player->getEyePos();
+		$direction = $player->getDirectionVector()->normalize();
+		$searchBox = $player->getBoundingBox()->expandedCopy(self::MAX_STAB_DISTANCE, self::MAX_STAB_DISTANCE, self::MAX_STAB_DISTANCE);
+
+		$target = null;
+		$bestScore = -1.0;
+
+		foreach($player->getWorld()->getNearbyEntities($searchBox, $player) as $entity){
+			if(!$entity instanceof Living || !$entity->isAlive()){
+				continue;
+			}
+
+			$targetPos = $entity->getPosition()->add(0, $entity->getEyeHeight() * 0.5, 0);
+			$distance = $eyePos->distance($targetPos);
+			if($distance > self::MAX_STAB_DISTANCE || $distance <= 0){
+				continue;
+			}
+
+			$dot = $direction->dot($targetPos->subtractVector($eyePos)->normalize());
+			if($dot < 0.866){
+				continue;
+			}
+
+			$score = $dot - ($distance / self::MAX_STAB_DISTANCE) * 0.1;
+			if($score <= $bestScore){
+				continue;
+			}
+
+			$bestScore = $score;
+			$target = $entity;
+		}
+
+		return $target;
+	}
+
+	/**
+	 * Finds the closest living entity inside the box just in front of the player.
+	 */
+	private function findSweepTarget(Player $player) : ?Living{
+		$direction = $player->getDirectionVector()->normalize()->multiply(1.5);
+		$searchBox = $player->getBoundingBox()
+			->expandedCopy(1.5, 1.0, 1.5)
+			->offset($direction->x, $direction->y, $direction->z);
+
+		$target = null;
+		$closestDistance = PHP_FLOAT_MAX;
+
+		foreach($player->getWorld()->getNearbyEntities($searchBox, $player) as $entity){
+			if(!$entity instanceof Living || !$entity->isAlive()){
+				continue;
+			}
+
+			$distance = $entity->getPosition()->distanceSquared($player->getPosition());
+			if($distance >= $closestDistance){
+				continue;
+			}
+
+			$closestDistance = $distance;
+			$target = $entity;
+		}
+
+		return $target;
+	}
+
+	private function getLungeSound(int $lungeLevel) : Sound{
+		return new SpearLungeSound(min($lungeLevel, VanillaEnchantments::LUNGE()->getMaxLevel()));
+	}
+
+	private function getHitSound() : Sound{
+		return match($this->tier){
+			ToolTier::WOOD => new WoodenSpearAttackHitSound(),
+			ToolTier::STONE => new StoneSpearAttackHitSound(),
+			ToolTier::COPPER => new CopperSpearAttackHitSound(),
+			ToolTier::IRON => new IronSpearAttackHitSound(),
+			ToolTier::GOLD => new GoldenSpearAttackHitSound(),
+			ToolTier::DIAMOND => new DiamondSpearAttackHitSound(),
+			ToolTier::NETHERITE => new NetheriteSpearAttackHitSound(),
+		};
+	}
+
+	private function getMissSound() : Sound{
+		return match($this->tier){
+			ToolTier::WOOD => new WoodenSpearAttackMissSound(),
+			ToolTier::STONE => new StoneSpearAttackMissSound(),
+			ToolTier::COPPER => new CopperSpearAttackMissSound(),
+			ToolTier::IRON => new IronSpearAttackMissSound(),
+			ToolTier::GOLD => new GoldenSpearAttackMissSound(),
+			ToolTier::DIAMOND => new DiamondSpearAttackMissSound(),
+			ToolTier::NETHERITE => new NetheriteSpearAttackMissSound(),
+		};
+	}
+
+	private function getUseSound() : Sound{
+		return match($this->tier){
+			ToolTier::WOOD => new WoodenSpearUseSound(),
+			ToolTier::STONE => new StoneSpearUseSound(),
+			ToolTier::COPPER => new CopperSpearUseSound(),
+			ToolTier::IRON => new IronSpearUseSound(),
+			ToolTier::GOLD => new GoldenSpearUseSound(),
+			ToolTier::DIAMOND => new DiamondSpearUseSound(),
+			ToolTier::NETHERITE => new NetheriteSpearUseSound(),
+		};
+	}
+}

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1651,6 +1651,13 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("tide_armor_trim_smithing_template", fn() => Items::TIDE_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$result->register("totem", fn() => Items::TOTEM());
 		$result->register("trident", fn() => Items::TRIDENT());
+		$result->register("copper_spear", fn() => Items::COPPER_SPEAR());
+		$result->register("diamond_spear", fn() => Items::DIAMOND_SPEAR());
+		$result->register("golden_spear", fn() => Items::GOLDEN_SPEAR());
+		$result->register("iron_spear", fn() => Items::IRON_SPEAR());
+		$result->register("netherite_spear", fn() => Items::NETHERITE_SPEAR());
+		$result->register("stone_spear", fn() => Items::STONE_SPEAR());
+		$result->register("wooden_spear", fn() => Items::WOODEN_SPEAR());
 		$result->register("turtle_helmet", fn() => Items::TURTLE_HELMET());
 		$result->register("vex_armor_trim_smithing_template", fn() => Items::VEX_ARMOR_TRIM_SMITHING_TEMPLATE());
 		$result->register("turtle_shell_piece", fn() => Items::SCUTE());

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -382,6 +382,7 @@ final class VanillaItemsInputs extends RegistrySource{
 			self::register($idPrefix . "_pickaxe", fn(IID $id) => new Pickaxe($id, $namePrefix . " Pickaxe", $tier, [EnchantmentTags::PICKAXE]));
 			self::register($idPrefix . "_shovel", fn(IID $id) => new Shovel($id, $namePrefix . " Shovel", $tier, [EnchantmentTags::SHOVEL]));
 			self::register($idPrefix . "_sword", fn(IID $id) => new Sword($id, $namePrefix . " Sword", $tier, [EnchantmentTags::SWORD]));
+			self::register($idPrefix . "_spear", fn(IID $id) => new Spear($id, $namePrefix . " Spear", $tier, [EnchantmentTags::SPEAR]));
 		}
 	}
 

--- a/src/item/enchantment/AvailableEnchantmentRegistry.php
+++ b/src/item/enchantment/AvailableEnchantmentRegistry.php
@@ -84,6 +84,7 @@ final class AvailableEnchantmentRegistry{
 		);
 		$this->register(Enchantments::VANISHING(), [], [Tags::ALL]);
 		$this->register(Enchantments::SWIFT_SNEAK(), [], [Tags::LEGGINGS]);
+		$this->register(Enchantments::LUNGE(), [Tags::SPEAR], []);
 	}
 
 	/**

--- a/src/item/enchantment/ItemEnchantmentTagRegistry.php
+++ b/src/item/enchantment/ItemEnchantmentTagRegistry.php
@@ -55,6 +55,7 @@ final class ItemEnchantmentTagRegistry{
 		$this->register(Tags::SHIELD);
 		$this->register(Tags::SWORD);
 		$this->register(Tags::TRIDENT);
+		$this->register(Tags::SPEAR);
 		$this->register(Tags::BOW);
 		$this->register(Tags::CROSSBOW);
 		$this->register(Tags::SHEARS);
@@ -69,6 +70,7 @@ final class ItemEnchantmentTagRegistry{
 		$this->register(Tags::WEAPONS, [
 			Tags::SWORD,
 			Tags::TRIDENT,
+			Tags::SPEAR,
 			Tags::BOW,
 			Tags::CROSSBOW,
 			Tags::BLOCK_TOOLS,

--- a/src/item/enchantment/ItemEnchantmentTags.php
+++ b/src/item/enchantment/ItemEnchantmentTags.php
@@ -40,6 +40,7 @@ final class ItemEnchantmentTags{
 	public const SHIELD = "shield";
 	public const SWORD = "sword";
 	public const TRIDENT = "trident";
+	public const SPEAR = "spear";
 	public const BOW = "bow";
 	public const CROSSBOW = "crossbow";
 	public const SHEARS = "shears";

--- a/src/item/enchantment/StringToEnchantmentParser.php
+++ b/src/item/enchantment/StringToEnchantmentParser.php
@@ -49,6 +49,7 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result->register("frost_walker", fn() => VanillaEnchantments::FROST_WALKER());
 		$result->register("infinity", fn() => VanillaEnchantments::INFINITY());
 		$result->register("knockback", fn() => VanillaEnchantments::KNOCKBACK());
+		$result->register("lunge", fn() => VanillaEnchantments::LUNGE());
 		$result->register("mending", fn() => VanillaEnchantments::MENDING());
 		$result->register("power", fn() => VanillaEnchantments::POWER());
 		$result->register("projectile_protection", fn() => VanillaEnchantments::PROJECTILE_PROTECTION());

--- a/src/item/enchantment/VanillaEnchantmentsInputs.php
+++ b/src/item/enchantment/VanillaEnchantmentsInputs.php
@@ -280,6 +280,16 @@ final class VanillaEnchantmentsInputs extends RegistrySource{
 			fn(int $level) : int => 10 * $level,
 			5
 		));
+
+		self::register("LUNGE", new Enchantment(
+			"enchantment.lunge",
+			Rarity::UNCOMMON,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 10 * $level,
+			25
+		));
 	}
 
 	protected function register(string $name, Enchantment $member) : void{

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -107,6 +107,7 @@ use pocketmine\item\enchantment\MeleeWeaponEnchantment;
 use pocketmine\item\Item;
 use pocketmine\item\ItemUseResult;
 use pocketmine\item\Releasable;
+use pocketmine\item\Spear;
 use pocketmine\lang\KnownTranslationFactory;
 use pocketmine\lang\Language;
 use pocketmine\lang\Translatable;
@@ -1582,6 +1583,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			}
 
 			$item = $this->getInventory()->getItemInHand();
+			if($item instanceof Spear && $this->isUsingItem()){
+				$item->whileSpearUsing($this);
+			}
 			if($item instanceof ConsumableItem && $this->isUsingItem()){
 				if($this->getItemUseDuration() >= $item->getMinUseDuration()){
 					$this->consumeHeldItem();

--- a/src/world/sound/CopperSpearAttackHitSound.php
+++ b/src/world/sound/CopperSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class CopperSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_COPPER_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/CopperSpearAttackMissSound.php
+++ b/src/world/sound/CopperSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class CopperSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_COPPER_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/CopperSpearUseSound.php
+++ b/src/world/sound/CopperSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class CopperSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_COPPER_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/DiamondSpearAttackHitSound.php
+++ b/src/world/sound/DiamondSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class DiamondSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_DIAMOND_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/DiamondSpearAttackMissSound.php
+++ b/src/world/sound/DiamondSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class DiamondSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_DIAMOND_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/DiamondSpearUseSound.php
+++ b/src/world/sound/DiamondSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class DiamondSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_DIAMOND_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/GoldenSpearAttackHitSound.php
+++ b/src/world/sound/GoldenSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class GoldenSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_GOLDEN_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/GoldenSpearAttackMissSound.php
+++ b/src/world/sound/GoldenSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class GoldenSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_GOLDEN_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/GoldenSpearUseSound.php
+++ b/src/world/sound/GoldenSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class GoldenSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_GOLDEN_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/IronSpearAttackHitSound.php
+++ b/src/world/sound/IronSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class IronSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_IRON_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/IronSpearAttackMissSound.php
+++ b/src/world/sound/IronSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class IronSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_IRON_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/IronSpearUseSound.php
+++ b/src/world/sound/IronSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class IronSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_IRON_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/NetheriteSpearAttackHitSound.php
+++ b/src/world/sound/NetheriteSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class NetheriteSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_NETHERITE_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/NetheriteSpearAttackMissSound.php
+++ b/src/world/sound/NetheriteSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class NetheriteSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_NETHERITE_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/NetheriteSpearUseSound.php
+++ b/src/world/sound/NetheriteSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class NetheriteSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_NETHERITE_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/SpearLungeSound.php
+++ b/src/world/sound/SpearLungeSound.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class SpearLungeSound implements Sound{
+
+	public function __construct(private int $level){
+	}
+
+	public function encode(Vector3 $pos) : array{
+		$sound = match($this->level){
+			1 => LevelSoundEvent::ITEM_ENCHANT_LUNGE1,
+			2 => LevelSoundEvent::ITEM_ENCHANT_LUNGE2,
+			default => LevelSoundEvent::ITEM_ENCHANT_LUNGE3,
+		};
+
+		return [LevelSoundEventPacket::nonActorSound($sound, $pos, false)];
+	}
+}

--- a/src/world/sound/StoneSpearAttackHitSound.php
+++ b/src/world/sound/StoneSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class StoneSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_STONE_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/StoneSpearAttackMissSound.php
+++ b/src/world/sound/StoneSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class StoneSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_STONE_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/StoneSpearUseSound.php
+++ b/src/world/sound/StoneSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class StoneSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_STONE_SPEAR_USE, $pos, false)];
+	}
+}

--- a/src/world/sound/WoodenSpearAttackHitSound.php
+++ b/src/world/sound/WoodenSpearAttackHitSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class WoodenSpearAttackHitSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_WOODEN_SPEAR_ATTACK_HIT, $pos, false)];
+	}
+}

--- a/src/world/sound/WoodenSpearAttackMissSound.php
+++ b/src/world/sound/WoodenSpearAttackMissSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class WoodenSpearAttackMissSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_WOODEN_SPEAR_ATTACK_MISS, $pos, false)];
+	}
+}

--- a/src/world/sound/WoodenSpearUseSound.php
+++ b/src/world/sound/WoodenSpearUseSound.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\world\sound;
+
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class WoodenSpearUseSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::ITEM_WOODEN_SPEAR_USE, $pos, false)];
+	}
+}


### PR DESCRIPTION
Added the **Spear** item to Altay.

- Added the `Spear` base class along with its 7 typees: wooden, stone, copper, iron, golden, diam
ond and netherite

## Changes

### API changes

- Added `Spear::getJabDamage()`
- Added `Spear::canLunge(Player $player)`
- Added `Spear::applyLunge(Player $player)`
- Added `Spear::onTickUsing(Player $player)`
- Added `Spear::MINIMUM_SPEED`, `Spear::MINIMUM_LUNGE_FOOD`, `Spear::BASE_LUNGE_EXHAUST`, `Spear::STAB_C
OOLDOWN_TICKS`, `Spear::SWEEP_INTERVAL_TICKS`, `Spear::MAX_STAB_DISTANCE`
- Added `PlayerSpearStabEvent`, with `getItem()` and `getMovementSpeed()`

### Behavioural changes

Player is now calling  `Spear::onTickUsing()`
FIRST_UNUSED_ITEM_ID is now 20335

## Backwards compatibility

Lunge is enchant id 41 but in altay there is no the 38-40 enchants..

## Tests

Tested ingame the lunge enchant, enchant table, the spear and the spear sounds.