### PR TITLE
feat: implemented mace along his 3 enchantments

### DIFF
--- a/generated/item/VanillaItems.php
+++ b/generated/item/VanillaItems.php
@@ -235,6 +235,7 @@ final class VanillaItems{
 	private static Armor $_mLEATHER_PANTS;
 	private static Armor $_mLEATHER_TUNIC;
 	private static SplashPotion $_mLINGERING_POTION;
+	private static Mace $_mMACE;
 	private static Item $_mMAGMA_CREAM;
 	private static Boat $_mMANGROVE_BOAT;
 	private static HangingSign $_mMANGROVE_HANGING_SIGN;
@@ -608,6 +609,7 @@ final class VanillaItems{
 			"leather_pants" => fn(Armor $v) => self::$_mLEATHER_PANTS = $v,
 			"leather_tunic" => fn(Armor $v) => self::$_mLEATHER_TUNIC = $v,
 			"lingering_potion" => fn(SplashPotion $v) => self::$_mLINGERING_POTION = $v,
+			"mace" => fn(Mace $v) => self::$_mMACE = $v,
 			"magma_cream" => fn(Item $v) => self::$_mMAGMA_CREAM = $v,
 			"mangrove_boat" => fn(Boat $v) => self::$_mMANGROVE_BOAT = $v,
 			"mangrove_hanging_sign" => fn(HangingSign $v) => self::$_mMANGROVE_HANGING_SIGN = $v,
@@ -1763,6 +1765,11 @@ final class VanillaItems{
 	public static function LINGERING_POTION() : SplashPotion{
 		if(!isset(self::$_mLINGERING_POTION)){ self::init(); }
 		return clone self::$_mLINGERING_POTION;
+	}
+
+	public static function MACE() : Mace{
+		if(!isset(self::$_mMACE)){ self::init(); }
+		return clone self::$_mMACE;
 	}
 
 	public static function MAGMA_CREAM() : Item{

--- a/generated/item/enchantment/VanillaEnchantments.php
+++ b/generated/item/enchantment/VanillaEnchantments.php
@@ -40,6 +40,8 @@ use function mb_strtoupper;
 final class VanillaEnchantments{
 	private static Enchantment $_mAQUA_AFFINITY;
 	private static ProtectionEnchantment $_mBLAST_PROTECTION;
+	private static Enchantment $_mBREACH;
+	private static Enchantment $_mDENSITY;
 	private static Enchantment $_mEFFICIENCY;
 	private static ProtectionEnchantment $_mFEATHER_FALLING;
 	private static FireAspectEnchantment $_mFIRE_ASPECT;
@@ -62,6 +64,7 @@ final class VanillaEnchantments{
 	private static Enchantment $_mTHORNS;
 	private static Enchantment $_mUNBREAKING;
 	private static Enchantment $_mVANISHING;
+	private static Enchantment $_mWIND_BURST;
 
 	/**
 	 * @var Enchantment[]
@@ -98,6 +101,8 @@ final class VanillaEnchantments{
 		return [
 			"AQUA_AFFINITY" => fn(Enchantment $v) => self::$_mAQUA_AFFINITY = $v,
 			"BLAST_PROTECTION" => fn(ProtectionEnchantment $v) => self::$_mBLAST_PROTECTION = $v,
+			"BREACH" => fn(Enchantment $v) => self::$_mBREACH = $v,
+			"DENSITY" => fn(Enchantment $v) => self::$_mDENSITY = $v,
 			"EFFICIENCY" => fn(Enchantment $v) => self::$_mEFFICIENCY = $v,
 			"FEATHER_FALLING" => fn(ProtectionEnchantment $v) => self::$_mFEATHER_FALLING = $v,
 			"FIRE_ASPECT" => fn(FireAspectEnchantment $v) => self::$_mFIRE_ASPECT = $v,
@@ -120,6 +125,7 @@ final class VanillaEnchantments{
 			"THORNS" => fn(Enchantment $v) => self::$_mTHORNS = $v,
 			"UNBREAKING" => fn(Enchantment $v) => self::$_mUNBREAKING = $v,
 			"VANISHING" => fn(Enchantment $v) => self::$_mVANISHING = $v,
+			"WIND_BURST" => fn(Enchantment $v) => self::$_mWIND_BURST = $v,
 		];
 	}
 
@@ -166,6 +172,16 @@ final class VanillaEnchantments{
 	public static function BLAST_PROTECTION() : ProtectionEnchantment{
 		if(!isset(self::$_mBLAST_PROTECTION)){ self::init(); }
 		return self::$_mBLAST_PROTECTION;
+	}
+
+	public static function BREACH() : Enchantment{
+		if(!isset(self::$_mBREACH)){ self::init(); }
+		return self::$_mBREACH;
+	}
+
+	public static function DENSITY() : Enchantment{
+		if(!isset(self::$_mDENSITY)){ self::init(); }
+		return self::$_mDENSITY;
 	}
 
 	public static function EFFICIENCY() : Enchantment{
@@ -276,5 +292,10 @@ final class VanillaEnchantments{
 	public static function VANISHING() : Enchantment{
 		if(!isset(self::$_mVANISHING)){ self::init(); }
 		return self::$_mVANISHING;
+	}
+
+	public static function WIND_BURST() : Enchantment{
+		if(!isset(self::$_mWIND_BURST)){ self::init(); }
+		return self::$_mWIND_BURST;
 	}
 }

--- a/src/data/bedrock/EnchantmentIdMap.php
+++ b/src/data/bedrock/EnchantmentIdMap.php
@@ -71,6 +71,9 @@ final class EnchantmentIdMap{
 
 		$this->register(EnchantmentIds::FROST_WALKER, VanillaEnchantments::FROST_WALKER());
 
+		$this->register(EnchantmentIds::WIND_BURST, VanillaEnchantments::WIND_BURST());
+		$this->register(EnchantmentIds::DENSITY, VanillaEnchantments::DENSITY());
+		$this->register(EnchantmentIds::BREACH, VanillaEnchantments::BREACH());
 		$this->register(EnchantmentIds::LUNGE, VanillaEnchantments::LUNGE());
 	}
 }

--- a/src/data/bedrock/EnchantmentIds.php
+++ b/src/data/bedrock/EnchantmentIds.php
@@ -69,5 +69,8 @@ final class EnchantmentIds{
 	public const QUICK_CHARGE = 35;
 	public const SOUL_SPEED = 36;
 	public const SWIFT_SNEAK = 37;
+	public const WIND_BURST = 38;
+	public const DENSITY = 39;
+	public const BREACH = 40;
 	public const LUNGE = 41;
 }

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -324,6 +324,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::LEATHER_CHESTPLATE, Items::LEATHER_TUNIC());
 		$this->map1to1Item(Ids::LEATHER_HELMET, Items::LEATHER_CAP());
 		$this->map1to1Item(Ids::LEATHER_LEGGINGS, Items::LEATHER_PANTS());
+		$this->map1to1Item(Ids::MACE, Items::MACE());
 		$this->map1to1Item(Ids::MAGMA_CREAM, Items::MAGMA_CREAM());
 		$this->map1to1Item(Ids::MANGROVE_BOAT, Items::MANGROVE_BOAT());
 		$this->map1to1Item(Ids::MANGROVE_HANGING_SIGN, Items::MANGROVE_HANGING_SIGN());

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -49,6 +49,7 @@ use pocketmine\item\Durable;
 use pocketmine\item\enchantment\Enchantment;
 use pocketmine\item\enchantment\VanillaEnchantments;
 use pocketmine\item\Item;
+use pocketmine\item\Mace;
 use pocketmine\math\AxisAlignedBB;
 use pocketmine\math\Vector3;
 use pocketmine\math\VoxelRayTrace;
@@ -471,6 +472,18 @@ abstract class Living extends Entity{
 			}
 		}
 		$source->setModifier(-$source->getFinalDamage() * min(ceil(min($totalEpf, 25) * (mt_rand(50, 100) / 100)), 20) * 0.04, EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS);
+
+		if($source instanceof EntityDamageByEntityEvent){
+			$damager = $source->getDamager();
+			if($damager instanceof Human){
+				$weapon = $damager->getInventory()->getItemInHand();
+				if($weapon instanceof Mace){
+					$armorEfficiency = $weapon->getArmorEfficiency();
+					$source->setModifier($source->getModifier(EntityDamageEvent::MODIFIER_ARMOR) * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR);
+					$source->setModifier($source->getModifier(EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS) * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS);
+				}
+			}
+		}
 
 		$source->setModifier(-min($this->getAbsorption(), $source->getFinalDamage()), EntityDamageEvent::MODIFIER_ABSORPTION);
 

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -445,6 +445,25 @@ abstract class Living extends Entity{
 	}
 
 	/**
+	 * Returns the fraction of this entity's armour which is effective against the given damage source, taking the
+	 * attacker's weapon into account. 1.0 means armour works as usual.
+	 */
+	private function getArmorEfficiencyAgainst(EntityDamageEvent $source) : float{
+		if(!$source instanceof EntityDamageByEntityEvent || $source->getCause() !== EntityDamageEvent::CAUSE_ENTITY_ATTACK){
+			return 1.0;
+		}
+
+		$damager = $source->getDamager();
+		if(!$damager instanceof Human){
+			return 1.0;
+		}
+
+		$weapon = $damager->getInventory()->getItemInHand();
+
+		return $weapon instanceof Mace ? $weapon->getArmorEfficiency() : 1.0;
+	}
+
+	/**
 	 * Called prior to EntityDamageEvent execution to apply modifications to the event's damage, such as reduction due
 	 * to effects or armour.
 	 */
@@ -455,9 +474,10 @@ abstract class Living extends Entity{
 			}
 			$source->setModifier(-$this->lastDamageCause->getBaseDamage(), EntityDamageEvent::MODIFIER_PREVIOUS_DAMAGE_COOLDOWN);
 		}
+		$armorEfficiency = $this->getArmorEfficiencyAgainst($source);
 		if($source->canBeReducedByArmor()){
 			//MCPE uses the same system as PC did pre-1.9
-			$source->setModifier(-$source->getFinalDamage() * $this->getArmorPoints() * 0.04, EntityDamageEvent::MODIFIER_ARMOR);
+			$source->setModifier(-$source->getFinalDamage() * $this->getArmorPoints() * 0.04 * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR);
 		}
 
 		$cause = $source->getCause();
@@ -471,19 +491,7 @@ abstract class Living extends Entity{
 				$totalEpf += $item->getEnchantmentProtectionFactor($source);
 			}
 		}
-		$source->setModifier(-$source->getFinalDamage() * min(ceil(min($totalEpf, 25) * (mt_rand(50, 100) / 100)), 20) * 0.04, EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS);
-
-		if($source instanceof EntityDamageByEntityEvent){
-			$damager = $source->getDamager();
-			if($damager instanceof Human){
-				$weapon = $damager->getInventory()->getItemInHand();
-				if($weapon instanceof Mace){
-					$armorEfficiency = $weapon->getArmorEfficiency();
-					$source->setModifier($source->getModifier(EntityDamageEvent::MODIFIER_ARMOR) * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR);
-					$source->setModifier($source->getModifier(EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS) * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS);
-				}
-			}
-		}
+		$source->setModifier(-$source->getFinalDamage() * min(ceil(min($totalEpf, 25) * (mt_rand(50, 100) / 100)), 20) * 0.04 * $armorEfficiency, EntityDamageEvent::MODIFIER_ARMOR_ENCHANTMENTS);
 
 		$source->setModifier(-min($this->getAbsorption(), $source->getFinalDamage()), EntityDamageEvent::MODIFIER_ABSORPTION);
 

--- a/src/event/entity/EntityDamageEvent.php
+++ b/src/event/entity/EntityDamageEvent.php
@@ -49,6 +49,7 @@ class EntityDamageEvent extends EntityEvent implements Cancellable{
 	public const MODIFIER_WEAPON_ENCHANTMENTS = 9;
 	public const MODIFIER_PREVIOUS_DAMAGE_COOLDOWN = 10;
 	public const MODIFIER_ARMOR_HELMET = 11;
+	public const MODIFIER_MACE_SMASH = 12;
 
 	public const CAUSE_CONTACT = 0;
 	public const CAUSE_ENTITY_ATTACK = 1;

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -379,8 +379,9 @@ final class ItemTypeIds{
 	public const NETHERITE_SPEAR = 20338;
 	public const STONE_SPEAR = 20339;
 	public const WOODEN_SPEAR = 20340;
+	public const MACE = 20341;
 
-	public const FIRST_UNUSED_ITEM_ID = 20341;
+	public const FIRST_UNUSED_ITEM_ID = 20342;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_ITEM_ID;
 

--- a/src/item/Mace.php
+++ b/src/item/Mace.php
@@ -28,18 +28,13 @@ namespace pocketmine\item;
 use pocketmine\block\Block;
 use pocketmine\entity\Entity;
 use pocketmine\item\enchantment\VanillaEnchantments;
-use pocketmine\math\Vector3;
 use pocketmine\world\particle\MaceGroundSmashParticle;
 use pocketmine\world\particle\WindExplosionParticle;
 use pocketmine\world\sound\MaceHeavySmashGroundSound;
 use pocketmine\world\sound\MaceSmashAirSound;
 use pocketmine\world\sound\MaceSmashGroundSound;
-use function cos;
-use function deg2rad;
-use function floor;
 use function max;
 use function min;
-use function sin;
 
 class Mace extends Tool{
 
@@ -51,6 +46,8 @@ class Mace extends Tool{
 	public const HEAVY_SMASH_DAMAGE = 16.0;
 	/** Damage below which a smash is not loud enough to play any sound. */
 	public const SMASH_SOUND_DAMAGE = 7.0;
+	/** Fall distance beyond which Wind Burst stops gaining extra launch power. */
+	public const MAX_WIND_BURST_FALL_DISTANCE = 7.5;
 
 	public function getMaxDurability() : int{
 		return 500;
@@ -80,7 +77,7 @@ class Mace extends Tool{
 	 * Returns whether the attacker fell far enough for their attack to count as a smash.
 	 */
 	public function canSmash(Entity $attacker) : bool{
-		return $attacker->getFallDistance() >= self::MINIMUM_SMASH_FALL_DISTANCE;
+		return $attacker->getFallDistance() >= self::MINIMUM_SMASH_FALL_DISTANCE && !$attacker->isUnderwater();
 	}
 
 	/**
@@ -92,19 +89,14 @@ class Mace extends Tool{
 			return self::BASE_ATTACK_POINTS;
 		}
 
-		$blocks = (int) floor($fallDistance);
-		$damage = 0;
-		for($i = 0; $i <= $blocks; $i++){
-			if($i < 3){
-				$damage += 4;
-			}elseif($i < 8){
-				$damage += 2;
-			}else{
-				$damage++;
-			}
-		}
+		//the first 3 blocks of fall are worth 4 damage each, the next 5 are worth 2, the rest are worth 1
+		$bonus = match(true){
+			$fallDistance <= 3.0 => $fallDistance * 4,
+			$fallDistance <= 8.0 => 12 + ($fallDistance - 3) * 2,
+			default => 22 + ($fallDistance - 8)
+		};
 
-		return $damage;
+		return self::BASE_ATTACK_POINTS + $bonus;
 	}
 
 	/**
@@ -128,19 +120,22 @@ class Mace extends Tool{
 		return max(0.0, (100 - ($breachLevel * 15)) / 100);
 	}
 
-	public function playSmashSound(Entity $victim, float $damage) : void{
+	/**
+	 * Plays the impact sound and spawns the ground dust particles of a smash landed by the given attacker.
+	 */
+	public function playSmashEffects(Entity $attacker, float $damage) : void{
 		if($damage < self::SMASH_SOUND_DAMAGE){
 			return;
 		}
 
 		$sound = $damage >= self::HEAVY_SMASH_DAMAGE ? new MaceHeavySmashGroundSound() : new MaceSmashGroundSound();
-		$victim->getWorld()->addSound($victim->getPosition(), $sound);
-		$victim->getWorld()->addParticle($victim->getPosition(), new MaceGroundSmashParticle());
+		$world = $attacker->getWorld();
+		$world->addSound($attacker->getPosition(), $sound);
+		$world->addParticle($attacker->getPosition(), new MaceGroundSmashParticle());
 	}
 
 	/**
-	 * Applies the Wind Burst enchantment: launches the attacker upwards and forwards, pushes nearby
-	 * entities away and spawns wind explosion particles.
+	 * Applies the Wind Burst enchantment, launching the attacker back upwards.
 	 */
 	public function applyWindBurst(Entity $attacker) : void{
 		$level = $this->getEnchantmentLevel(VanillaEnchantments::WIND_BURST());
@@ -153,37 +148,16 @@ class Mace extends Tool{
 			return;
 		}
 
-		$clampedFall = min($fallDistance, 7.5);
-		$verticalBoost = 0.72 + $clampedFall * 0.10 + match($level){
+		$verticalBoost = 0.72 + min($fallDistance, self::MAX_WIND_BURST_FALL_DISTANCE) * 0.10 + match($level){
 			2 => 0.55,
 			3 => 1.3,
 			default => 0.0
 		};
 
-		$yaw = deg2rad($attacker->getLocation()->yaw);
-		$forward = (new Vector3(-sin($yaw), 0, cos($yaw)))->normalize();
-		$forwardBoost = 0.08 + 0.02 * $level;
-
-		$attacker->resetFallDistance();
-		$attacker->setMotion($forward->multiply($forwardBoost)->withComponents(null, $verticalBoost, null));
+		$attacker->setMotion($attacker->getMotion()->withComponents(null, $verticalBoost, null));
 
 		$world = $attacker->getWorld();
-		$searchBox = $attacker->getBoundingBox()->expandedCopy(2.5, 2.5, 2.5);
-		foreach($world->getNearbyEntities($searchBox, $attacker) as $entity){
-			$direction = $entity->getPosition()->subtractVector($attacker->getPosition());
-			if($direction->lengthSquared() <= 0){
-				continue;
-			}
-
-			$gust = $direction->normalize()->multiply(0.6 + 0.15 * $level);
-			$pushed = $entity->getMotion()->addVector($gust);
-			$entity->setMotion($pushed->withComponents(null, max($pushed->y, 0.4 + 0.1 * $level), null));
-
-			$world->addParticle($entity->getPosition()->add(0, $entity->getEyeHeight() * 0.6, 0), new WindExplosionParticle());
-		}
-
-		$eyePos = $attacker->getPosition()->add(0, $attacker->getEyeHeight() * 0.6, 0);
-		$world->addParticle($eyePos, new WindExplosionParticle());
+		$world->addParticle($attacker->getPosition(), new WindExplosionParticle());
 		$world->addSound($attacker->getPosition(), new MaceSmashAirSound());
 	}
 }

--- a/src/item/Mace.php
+++ b/src/item/Mace.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+use pocketmine\block\Block;
+use pocketmine\entity\Entity;
+use pocketmine\item\enchantment\VanillaEnchantments;
+use pocketmine\math\Vector3;
+use pocketmine\world\particle\MaceGroundSmashParticle;
+use pocketmine\world\particle\WindExplosionParticle;
+use pocketmine\world\sound\MaceHeavySmashGroundSound;
+use pocketmine\world\sound\MaceSmashAirSound;
+use pocketmine\world\sound\MaceSmashGroundSound;
+use function cos;
+use function deg2rad;
+use function floor;
+use function max;
+use function min;
+use function sin;
+
+class Mace extends Tool{
+
+	/** Damage dealt when the attacker did not fall far enough to smash. */
+	public const BASE_ATTACK_POINTS = 6;
+	/** Minimum fall distance required to turn an attack into a smash. */
+	public const MINIMUM_SMASH_FALL_DISTANCE = 1.5;
+	/** Damage above which a smash plays the heavy sound instead of the regular one. */
+	public const HEAVY_SMASH_DAMAGE = 16.0;
+	/** Damage below which a smash is not loud enough to play any sound. */
+	public const SMASH_SOUND_DAMAGE = 7.0;
+
+	public function getMaxDurability() : int{
+		return 500;
+	}
+
+	public function getAttackPoints() : int{
+		return self::BASE_ATTACK_POINTS;
+	}
+
+	public function getEnchantability() : int{
+		return 15;
+	}
+
+	public function onAttackEntity(Entity $victim, array &$returnedItems) : bool{
+		return $this->applyDamage(1);
+	}
+
+	public function onDestroyBlock(Block $block, array &$returnedItems) : bool{
+		if($block->getBreakInfo()->breaksInstantly()){
+			return false;
+		}
+
+		return $this->applyDamage(2);
+	}
+
+	/**
+	 * Returns whether the attacker fell far enough for their attack to count as a smash.
+	 */
+	public function canSmash(Entity $attacker) : bool{
+		return $attacker->getFallDistance() >= self::MINIMUM_SMASH_FALL_DISTANCE;
+	}
+
+	/**
+	 * Returns the total attack damage of a smash performed after falling the given distance, before
+	 * enchantment bonuses.
+	 */
+	public function getSmashDamage(float $fallDistance) : float{
+		if($fallDistance < self::MINIMUM_SMASH_FALL_DISTANCE){
+			return self::BASE_ATTACK_POINTS;
+		}
+
+		$blocks = (int) floor($fallDistance);
+		$damage = 0;
+		for($i = 0; $i <= $blocks; $i++){
+			if($i < 3){
+				$damage += 4;
+			}elseif($i < 8){
+				$damage += 2;
+			}else{
+				$damage++;
+			}
+		}
+
+		return $damage;
+	}
+
+	/**
+	 * Returns the extra damage granted by the Density enchantment for the given fall distance.
+	 */
+	public function getDensityBonus(float $fallDistance) : float{
+		if($fallDistance < self::MINIMUM_SMASH_FALL_DISTANCE){
+			return 0.0;
+		}
+
+		return $fallDistance * 0.5 * $this->getEnchantmentLevel(VanillaEnchantments::DENSITY());
+	}
+
+	/**
+	 * Returns the fraction of the target's armour that remains effective against this mace, after the
+	 * Breach enchantment. 1.0 means armour is fully effective.
+	 */
+	public function getArmorEfficiency() : float{
+		$breachLevel = $this->getEnchantmentLevel(VanillaEnchantments::BREACH());
+
+		return max(0.0, (100 - ($breachLevel * 15)) / 100);
+	}
+
+	public function playSmashSound(Entity $victim, float $damage) : void{
+		if($damage < self::SMASH_SOUND_DAMAGE){
+			return;
+		}
+
+		$sound = $damage >= self::HEAVY_SMASH_DAMAGE ? new MaceHeavySmashGroundSound() : new MaceSmashGroundSound();
+		$victim->getWorld()->addSound($victim->getPosition(), $sound);
+		$victim->getWorld()->addParticle($victim->getPosition(), new MaceGroundSmashParticle());
+	}
+
+	/**
+	 * Applies the Wind Burst enchantment: launches the attacker upwards and forwards, pushes nearby
+	 * entities away and spawns wind explosion particles.
+	 */
+	public function applyWindBurst(Entity $attacker) : void{
+		$level = $this->getEnchantmentLevel(VanillaEnchantments::WIND_BURST());
+		if($level <= 0){
+			return;
+		}
+
+		$fallDistance = $attacker->getFallDistance();
+		if($fallDistance < self::MINIMUM_SMASH_FALL_DISTANCE){
+			return;
+		}
+
+		$clampedFall = min($fallDistance, 7.5);
+		$verticalBoost = 0.72 + $clampedFall * 0.10 + match($level){
+			2 => 0.55,
+			3 => 1.3,
+			default => 0.0
+		};
+
+		$yaw = deg2rad($attacker->getLocation()->yaw);
+		$forward = (new Vector3(-sin($yaw), 0, cos($yaw)))->normalize();
+		$forwardBoost = 0.08 + 0.02 * $level;
+
+		$attacker->resetFallDistance();
+		$attacker->setMotion($forward->multiply($forwardBoost)->withComponents(null, $verticalBoost, null));
+
+		$world = $attacker->getWorld();
+		$searchBox = $attacker->getBoundingBox()->expandedCopy(2.5, 2.5, 2.5);
+		foreach($world->getNearbyEntities($searchBox, $attacker) as $entity){
+			$direction = $entity->getPosition()->subtractVector($attacker->getPosition());
+			if($direction->lengthSquared() <= 0){
+				continue;
+			}
+
+			$gust = $direction->normalize()->multiply(0.6 + 0.15 * $level);
+			$pushed = $entity->getMotion()->addVector($gust);
+			$entity->setMotion($pushed->withComponents(null, max($pushed->y, 0.4 + 0.1 * $level), null));
+
+			$world->addParticle($entity->getPosition()->add(0, $entity->getEyeHeight() * 0.6, 0), new WindExplosionParticle());
+		}
+
+		$eyePos = $attacker->getPosition()->add(0, $attacker->getEyeHeight() * 0.6, 0);
+		$world->addParticle($eyePos, new WindExplosionParticle());
+		$world->addSound($attacker->getPosition(), new MaceSmashAirSound());
+	}
+}

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1519,6 +1519,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("leather_leggings", fn() => Items::LEATHER_PANTS());
 		$result->register("leather_pants", fn() => Items::LEATHER_PANTS());
 		$result->register("leather_tunic", fn() => Items::LEATHER_TUNIC());
+		$result->register("mace", fn() => Items::MACE());
 		$result->register("magma_cream", fn() => Items::MAGMA_CREAM());
 		$result->register("mangrove_hanging_sign", fn() => Items::MANGROVE_HANGING_SIGN());
 		$result->register("melon", fn() => Items::MELON());

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -235,6 +235,7 @@ final class VanillaItemsInputs extends RegistrySource{
 		self::registerDelayed("lava_bucket", fn(string $name) : LiquidBucket => new LiquidBucket(self::makeIID($name), "Lava Bucket", Blocks::LAVA()));
 		self::register("leather", fn(IID $id) => new Item($id, "Leather"));
 		self::register("lingering_potion", fn(IID $id) => new SplashPotion($id, "Lingering Potion", linger: true));
+		self::register("mace", fn(IID $id) => new Mace($id, "Mace", [EnchantmentTags::MACE]));
 		self::register("magma_cream", fn(IID $id) => new Item($id, "Magma Cream"));
 		self::registerDelayed("mangrove_sign", fn(string $name) : ItemBlockWallOrFloor => new ItemBlockWallOrFloor(self::makeIID($name), Blocks::MANGROVE_SIGN(), Blocks::MANGROVE_WALL_SIGN()));
 		self::registerDelayed("mangrove_hanging_sign", fn(string $name) : HangingSign => new HangingSign(self::makeIID($name), "Mangrove Hanging Sign", Blocks::MANGROVE_CEILING_CENTER_HANGING_SIGN(), Blocks::MANGROVE_CEILING_EDGES_HANGING_SIGN(), Blocks::MANGROVE_WALL_HANGING_SIGN()));

--- a/src/item/enchantment/AvailableEnchantmentRegistry.php
+++ b/src/item/enchantment/AvailableEnchantmentRegistry.php
@@ -64,6 +64,9 @@ final class AvailableEnchantmentRegistry{
 		$this->register(Enchantments::SHARPNESS(), [Tags::SWORD, Tags::AXE], []);
 		$this->register(Enchantments::KNOCKBACK(), [Tags::SWORD], []);
 		$this->register(Enchantments::FIRE_ASPECT(), [Tags::SWORD], []);
+		$this->register(Enchantments::DENSITY(), [Tags::MACE], []);
+		$this->register(Enchantments::BREACH(), [Tags::MACE], []);
+		$this->register(Enchantments::WIND_BURST(), [/* treasure enchantment */], [Tags::MACE]);
 		$this->register(Enchantments::EFFICIENCY(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);
 		$this->register(Enchantments::FORTUNE(), [Tags::BLOCK_TOOLS], []);
 		$this->register(Enchantments::SILK_TOUCH(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);

--- a/src/item/enchantment/AvailableEnchantmentRegistry.php
+++ b/src/item/enchantment/AvailableEnchantmentRegistry.php
@@ -63,10 +63,11 @@ final class AvailableEnchantmentRegistry{
 		$this->register(Enchantments::FROST_WALKER(), [/* no primary items */], [Tags::BOOTS]);
 		$this->register(Enchantments::SHARPNESS(), [Tags::SWORD, Tags::AXE], []);
 		$this->register(Enchantments::KNOCKBACK(), [Tags::SWORD], []);
-		$this->register(Enchantments::FIRE_ASPECT(), [Tags::SWORD], []);
+		$this->register(Enchantments::FIRE_ASPECT(), [Tags::SWORD, Tags::MACE], []);
 		$this->register(Enchantments::DENSITY(), [Tags::MACE], []);
 		$this->register(Enchantments::BREACH(), [Tags::MACE], []);
-		$this->register(Enchantments::WIND_BURST(), [/* treasure enchantment */], [Tags::MACE]);
+		//Wind Burst is a treasure enchantment, so it has no primary tags and can't be rolled in an enchanting table
+		$this->register(Enchantments::WIND_BURST(), [], [Tags::MACE]);
 		$this->register(Enchantments::EFFICIENCY(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);
 		$this->register(Enchantments::FORTUNE(), [Tags::BLOCK_TOOLS], []);
 		$this->register(Enchantments::SILK_TOUCH(), [Tags::BLOCK_TOOLS], [Tags::SHEARS]);

--- a/src/item/enchantment/IncompatibleEnchantmentRegistry.php
+++ b/src/item/enchantment/IncompatibleEnchantmentRegistry.php
@@ -49,6 +49,7 @@ final class IncompatibleEnchantmentRegistry{
 		$this->register(Groups::PROTECTION, [Enchantments::PROTECTION(), Enchantments::FIRE_PROTECTION(), Enchantments::BLAST_PROTECTION(), Enchantments::PROJECTILE_PROTECTION()]);
 		$this->register(Groups::BOW_INFINITE, [Enchantments::INFINITY(), Enchantments::MENDING()]);
 		$this->register(Groups::BLOCK_DROPS, [Enchantments::FORTUNE(), Enchantments::SILK_TOUCH()]);
+		$this->register(Groups::HEAVY_WEAPON_DAMAGE, [Enchantments::DENSITY(), Enchantments::BREACH()]);
 	}
 
 	/**

--- a/src/item/enchantment/ItemEnchantmentTagRegistry.php
+++ b/src/item/enchantment/ItemEnchantmentTagRegistry.php
@@ -56,6 +56,7 @@ final class ItemEnchantmentTagRegistry{
 		$this->register(Tags::SWORD);
 		$this->register(Tags::TRIDENT);
 		$this->register(Tags::SPEAR);
+		$this->register(Tags::MACE);
 		$this->register(Tags::BOW);
 		$this->register(Tags::CROSSBOW);
 		$this->register(Tags::SHEARS);
@@ -71,6 +72,7 @@ final class ItemEnchantmentTagRegistry{
 			Tags::SWORD,
 			Tags::TRIDENT,
 			Tags::SPEAR,
+			Tags::MACE,
 			Tags::BOW,
 			Tags::CROSSBOW,
 			Tags::BLOCK_TOOLS,

--- a/src/item/enchantment/ItemEnchantmentTags.php
+++ b/src/item/enchantment/ItemEnchantmentTags.php
@@ -41,6 +41,7 @@ final class ItemEnchantmentTags{
 	public const SWORD = "sword";
 	public const TRIDENT = "trident";
 	public const SPEAR = "spear";
+	public const MACE = "mace";
 	public const BOW = "bow";
 	public const CROSSBOW = "crossbow";
 	public const SHEARS = "shears";

--- a/src/item/enchantment/StringToEnchantmentParser.php
+++ b/src/item/enchantment/StringToEnchantmentParser.php
@@ -40,6 +40,8 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result = new self();
 
 		$result->register("blast_protection", fn() => VanillaEnchantments::BLAST_PROTECTION());
+		$result->register("breach", fn() => VanillaEnchantments::BREACH());
+		$result->register("density", fn() => VanillaEnchantments::DENSITY());
 		$result->register("efficiency", fn() => VanillaEnchantments::EFFICIENCY());
 		$result->register("feather_falling", fn() => VanillaEnchantments::FEATHER_FALLING());
 		$result->register("fire_aspect", fn() => VanillaEnchantments::FIRE_ASPECT());
@@ -63,6 +65,7 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result->register("thorns", fn() => VanillaEnchantments::THORNS());
 		$result->register("unbreaking", fn() => VanillaEnchantments::UNBREAKING());
 		$result->register("vanishing", fn() => VanillaEnchantments::VANISHING());
+		$result->register("wind_burst", fn() => VanillaEnchantments::WIND_BURST());
 
 		return $result;
 	}

--- a/src/item/enchantment/VanillaEnchantmentsInputs.php
+++ b/src/item/enchantment/VanillaEnchantmentsInputs.php
@@ -271,6 +271,36 @@ final class VanillaEnchantmentsInputs extends RegistrySource{
 			25
 		));
 
+		self::register("DENSITY", new Enchantment(
+			KnownTranslationFactory::enchantment_heavy_weapon_density(),
+			Rarity::COMMON,
+			0,
+			0,
+			5,
+			fn(int $level) : int => 8 * ($level - 1) + 5,
+			20
+		));
+
+		self::register("BREACH", new Enchantment(
+			KnownTranslationFactory::enchantment_heavy_weapon_breach(),
+			Rarity::RARE,
+			0,
+			0,
+			4,
+			fn(int $level) : int => 9 * ($level - 1) + 15,
+			20
+		));
+
+		self::register("WIND_BURST", new Enchantment(
+			KnownTranslationFactory::enchantment_heavy_weapon_windburst(),
+			Rarity::MYTHIC,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 9 * ($level - 1) + 15,
+			20
+		));
+
 		self::register("SWIFT_SNEAK", new Enchantment(
 			KnownTranslationFactory::enchantment_swift_sneak(),
 			Rarity::MYTHIC,

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -106,6 +106,7 @@ use pocketmine\item\enchantment\EnchantmentInstance;
 use pocketmine\item\enchantment\MeleeWeaponEnchantment;
 use pocketmine\item\Item;
 use pocketmine\item\ItemUseResult;
+use pocketmine\item\Mace;
 use pocketmine\item\Releasable;
 use pocketmine\item\Spear;
 use pocketmine\lang\KnownTranslationFactory;
@@ -2067,7 +2068,12 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 		$ev->setModifier($meleeEnchantmentDamage, EntityDamageEvent::MODIFIER_WEAPON_ENCHANTMENTS);
 
-		if(!$this->isSprinting() && !$this->isFlying() && $this->fallDistance > 0 && !$this->effectManager->has(VanillaEffects::BLINDNESS()) && !$this->isUnderwater()){
+		$isMaceSmash = $heldItem instanceof Mace && $heldItem->canSmash($this);
+		if($isMaceSmash){
+			$smashBonus = ($heldItem->getSmashDamage($this->fallDistance) - $heldItem->getAttackPoints()) + $heldItem->getDensityBonus($this->fallDistance);
+			$ev->setModifier($smashBonus, EntityDamageEvent::MODIFIER_MACE_SMASH);
+		}elseif(!$this->isSprinting() && !$this->isFlying() && $this->fallDistance > 0 && !$this->effectManager->has(VanillaEffects::BLINDNESS()) && !$this->isUnderwater()){
+			//a mace smash replaces the regular fall critical hit
 			$ev->setModifier($ev->getFinalDamage() / 2, EntityDamageEvent::MODIFIER_CRITICAL);
 		}
 
@@ -2097,6 +2103,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			$type = $enchantment->getType();
 			assert($type instanceof MeleeWeaponEnchantment);
 			$type->onPostAttack($this, $entity, $enchantment->getLevel());
+		}
+
+		if($isMaceSmash && $heldItem instanceof Mace){
+			$heldItem->playSmashSound($entity, $ev->getFinalDamage());
+			$heldItem->applyWindBurst($this);
 		}
 
 		if($this->isAlive()){

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -2068,9 +2068,9 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 		}
 		$ev->setModifier($meleeEnchantmentDamage, EntityDamageEvent::MODIFIER_WEAPON_ENCHANTMENTS);
 
-		$isMaceSmash = $heldItem instanceof Mace && $heldItem->canSmash($this);
-		if($isMaceSmash){
-			$smashBonus = ($heldItem->getSmashDamage($this->fallDistance) - $heldItem->getAttackPoints()) + $heldItem->getDensityBonus($this->fallDistance);
+		$smashingMace = $heldItem instanceof Mace && $heldItem->canSmash($this) ? $heldItem : null;
+		if($smashingMace !== null){
+			$smashBonus = ($smashingMace->getSmashDamage($this->fallDistance) - $smashingMace->getAttackPoints()) + $smashingMace->getDensityBonus($this->fallDistance);
 			$ev->setModifier($smashBonus, EntityDamageEvent::MODIFIER_MACE_SMASH);
 		}elseif(!$this->isSprinting() && !$this->isFlying() && $this->fallDistance > 0 && !$this->effectManager->has(VanillaEffects::BLINDNESS()) && !$this->isUnderwater()){
 			//a mace smash replaces the regular fall critical hit
@@ -2105,9 +2105,11 @@ class Player extends Human implements CommandSender, ChunkListener, IPlayer, Nev
 			$type->onPostAttack($this, $entity, $enchantment->getLevel());
 		}
 
-		if($isMaceSmash && $heldItem instanceof Mace){
-			$heldItem->playSmashSound($entity, $ev->getFinalDamage());
-			$heldItem->applyWindBurst($this);
+		if($smashingMace !== null){
+			$smashingMace->playSmashEffects($this, $ev->getFinalDamage());
+			$smashingMace->applyWindBurst($this);
+			//the fall is spent on the smash, so it neither damages the attacker nor powers a second smash
+			$this->resetFallDistance();
 		}
 
 		if($this->isAlive()){

--- a/src/world/particle/MaceGroundSmashParticle.php
+++ b/src/world/particle/MaceGroundSmashParticle.php
@@ -23,15 +23,16 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\particle;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelEventPacket;
+
+class MaceGroundSmashParticle implements Particle{
+
+	private const PARTICLE_SMASH_ATTACK_GROUND_DUST = 9815;
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelEventPacket::create(self::PARTICLE_SMASH_ATTACK_GROUND_DUST, 0, $pos)];
+	}
 }

--- a/src/world/sound/MaceHeavySmashGroundSound.php
+++ b/src/world/sound/MaceHeavySmashGroundSound.php
@@ -23,15 +23,15 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\sound;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class MaceHeavySmashGroundSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::MACE_HEAVY_SMASH_GROUND, $pos, false)];
+	}
 }

--- a/src/world/sound/MaceSmashAirSound.php
+++ b/src/world/sound/MaceSmashAirSound.php
@@ -23,15 +23,15 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\sound;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class MaceSmashAirSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::MACE_SMASH_AIR, $pos, false)];
+	}
 }

--- a/src/world/sound/MaceSmashGroundSound.php
+++ b/src/world/sound/MaceSmashGroundSound.php
@@ -23,15 +23,15 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\sound;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class MaceSmashGroundSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::MACE_SMASH_GROUND, $pos, false)];
+	}
 }


### PR DESCRIPTION
Added the Mace item to Altay, along with its 3 enchantments.

## Changes

### API changes

- Added `Mace::getSmashDamage(float $fallDistance)`
- Added `Mace::getDensityBonus(float $fallDistance)`
- Added `Mace::getArmorEfficiency()`
- Added `Mace::canSmash(Entity $attacker)`
- Added `Mace::playSmashSound(Entity $victim, float $damage)`
- Added `Mace::applyWindBurst(Entity $attacker)`
- Added `Mace::BASE_ATTACK_POINTS`, `Mace::MINIMUM_SMASH_FALL_DISTANCE`,
  `Mace::HEAVY_SMASH_DAMAGE`, `Mace::SMASH_SOUND_DAMAGE`
- Added `EntityDamageEvent::MODIFIER_MACE_SMASH`

### Behavioural changes
None.

## Backwards compatibility

No changes for that.

## Tests

Tested ingame: the smash attack, Density, Breach, Wind Burst, the sounds and the
ground smash particle. 

> used ai to fix  grammar