### PR TITLE
feat: implemented seagrass block

### DIFF
--- a/generated/block/VanillaBlocks.php
+++ b/generated/block/VanillaBlocks.php
@@ -744,6 +744,7 @@ final class VanillaBlocks{
 	private static Stair $_mSANDSTONE_STAIRS;
 	private static Wall $_mSANDSTONE_WALL;
 	private static Sculk $_mSCULK;
+	private static Seagrass $_mSEAGRASS;
 	private static SeaLantern $_mSEA_LANTERN;
 	private static SeaPickle $_mSEA_PICKLE;
 	private static Opaque $_mSHROOMLIGHT;
@@ -1608,6 +1609,7 @@ final class VanillaBlocks{
 			"sandstone_stairs" => fn(Stair $v) => self::$_mSANDSTONE_STAIRS = $v,
 			"sandstone_wall" => fn(Wall $v) => self::$_mSANDSTONE_WALL = $v,
 			"sculk" => fn(Sculk $v) => self::$_mSCULK = $v,
+			"seagrass" => fn(Seagrass $v) => self::$_mSEAGRASS = $v,
 			"sea_lantern" => fn(SeaLantern $v) => self::$_mSEA_LANTERN = $v,
 			"sea_pickle" => fn(SeaPickle $v) => self::$_mSEA_PICKLE = $v,
 			"shroomlight" => fn(Opaque $v) => self::$_mSHROOMLIGHT = $v,
@@ -5290,6 +5292,11 @@ final class VanillaBlocks{
 	public static function SCULK() : Sculk{
 		if(!isset(self::$_mSCULK)){ self::init(); }
 		return clone self::$_mSCULK;
+	}
+
+	public static function SEAGRASS() : Seagrass{
+		if(!isset(self::$_mSEAGRASS)){ self::init(); }
+		return clone self::$_mSEAGRASS;
 	}
 
 	public static function SEA_LANTERN() : SeaLantern{

--- a/src/block/BaseCoral.php
+++ b/src/block/BaseCoral.php
@@ -28,12 +28,14 @@ namespace pocketmine\block;
 use pocketmine\block\utils\BlockEventHelper;
 use pocketmine\block\utils\CoralMaterial;
 use pocketmine\block\utils\CoralTypeTrait;
+use pocketmine\block\utils\CoveredWithWaterTrait;
 use pocketmine\block\utils\SupportType;
 use pocketmine\item\Item;
 use function mt_rand;
 
 abstract class BaseCoral extends Transparent implements CoralMaterial{
 	use CoralTypeTrait;
+	use CoveredWithWaterTrait;
 
 	public function onNearbyBlockChange() : void{
 		if(!$this->dead){
@@ -56,21 +58,6 @@ abstract class BaseCoral extends Transparent implements CoralMaterial{
 	}
 
 	public function isSolid() : bool{ return false; }
-
-	protected function isCoveredWithWater() : bool{
-		$world = $this->position->getWorld();
-
-		$hasWater = false;
-		foreach($this->position->sides() as $vector3){
-			if($world->getBlock($vector3) instanceof Water){
-				$hasWater = true;
-				break;
-			}
-		}
-
-		//TODO: check water inside the block itself (not supported on the API yet)
-		return $hasWater;
-	}
 
 	protected function recalculateCollisionBoxes() : array{ return []; }
 

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -887,8 +887,9 @@ final class BlockTypeIds{
 	public const ALLOW = 10854;
 	public const DENY = 10855;
   public const DECORATED_POT = 10856;
+	public const SEAGRASS = 10857;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10857;
+	public const FIRST_UNUSED_BLOCK_ID = 10858;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/Seagrass.php
+++ b/src/block/Seagrass.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace pocketmine\block;
 
+use pocketmine\block\utils\CoveredWithWaterTrait;
 use pocketmine\block\utils\SeagrassType;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
@@ -34,9 +35,9 @@ use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
 use pocketmine\world\BlockTransaction;
-use function mt_rand;
 
 class Seagrass extends Transparent{
+	use CoveredWithWaterTrait;
 
 	protected SeagrassType $seagrassType = SeagrassType::NORMAL;
 
@@ -79,10 +80,6 @@ class Seagrass extends Transparent{
 	}
 
 	public function onNearbyBlockChange() : void{
-		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(40, 200));
-	}
-
-	public function onScheduledUpdate() : void{
 		if(!$this->isCoveredWithWater() || !$this->hasValidSupport()){
 			$this->position->getWorld()->useBreakOn($this->position);
 		}
@@ -106,7 +103,7 @@ class Seagrass extends Transparent{
 		return true;
 	}
 
-	public function getDrops(Item $item) : array{
+	public function getDropsForCompatibleTool(Item $item) : array{
 		if($this->seagrassType === SeagrassType::DOUBLE_TOP){
 			return [];
 		}
@@ -114,39 +111,38 @@ class Seagrass extends Transparent{
 		return [$this->asItem()];
 	}
 
-	private function hasValidSupport() : bool{
-		if($this->seagrassType === SeagrassType::DOUBLE_TOP){
-			$down = $this->getSide(Facing::DOWN);
-			return $down instanceof Seagrass && $down->seagrassType === SeagrassType::DOUBLE_BOTTOM;
+	public function getAffectedBlocks() : array{
+		$otherHalf = $this->getOtherHalf();
+
+		return $otherHalf !== null ? [$this, $otherHalf] : parent::getAffectedBlocks();
+	}
+
+	/**
+	 * Returns the matching half of this double seagrass, or null if this isn't a double seagrass or the other half is
+	 * missing.
+	 */
+	private function getOtherHalf() : ?Seagrass{
+		if($this->seagrassType === SeagrassType::NORMAL){
+			return null;
 		}
 
-		if(!$this->canSurviveOn($this->getSide(Facing::DOWN))){
+		$expected = $this->seagrassType === SeagrassType::DOUBLE_TOP ? SeagrassType::DOUBLE_BOTTOM : SeagrassType::DOUBLE_TOP;
+		$other = $this->getSide($this->seagrassType === SeagrassType::DOUBLE_TOP ? Facing::DOWN : Facing::UP);
+
+		return $other instanceof Seagrass && $other->seagrassType === $expected ? $other : null;
+	}
+
+	private function hasValidSupport() : bool{
+		if($this->seagrassType !== SeagrassType::NORMAL && $this->getOtherHalf() === null){
 			return false;
 		}
 
-		if($this->seagrassType === SeagrassType::DOUBLE_BOTTOM){
-			$up = $this->getSide(Facing::UP);
-			return $up instanceof Seagrass && $up->seagrassType === SeagrassType::DOUBLE_TOP;
-		}
-
-		return true;
+		return $this->seagrassType === SeagrassType::DOUBLE_TOP || $this->canSurviveOn($this->getSide(Facing::DOWN));
 	}
 
 	private function canSurviveOn(Block $block) : bool{
 		return $block->isSolid()
 			&& $block->getTypeId() !== BlockTypeIds::MAGMA
 			&& $block->getTypeId() !== BlockTypeIds::SOUL_SAND;
-	}
-
-	private function isCoveredWithWater() : bool{
-		$world = $this->position->getWorld();
-		foreach($this->position->sides() as $side){
-			if($world->getBlock($side) instanceof Water){
-				return true;
-			}
-		}
-
-		//TODO: check water inside the block itself (not supported on the API yet)
-		return false;
 	}
 }

--- a/src/block/Seagrass.php
+++ b/src/block/Seagrass.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\SeagrassType;
+use pocketmine\block\utils\SupportType;
+use pocketmine\data\runtime\RuntimeDataDescriber;
+use pocketmine\item\Fertilizer;
+use pocketmine\item\Item;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\BlockTransaction;
+use function mt_rand;
+
+class Seagrass extends Transparent{
+
+	protected SeagrassType $seagrassType = SeagrassType::NORMAL;
+
+	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
+		$w->enum($this->seagrassType);
+	}
+
+	public function getSeagrassType() : SeagrassType{
+		return $this->seagrassType;
+	}
+
+	/** @return $this */
+	public function setSeagrassType(SeagrassType $seagrassType) : self{
+		$this->seagrassType = $seagrassType;
+		return $this;
+	}
+
+	public function isSolid() : bool{
+		return false;
+	}
+
+	public function canBeReplaced() : bool{
+		return $this->seagrassType === SeagrassType::NORMAL;
+	}
+
+	protected function recalculateCollisionBoxes() : array{
+		return [];
+	}
+
+	public function getSupportType(int $facing) : SupportType{
+		return SupportType::NONE;
+	}
+
+	public function place(BlockTransaction $tx, Item $item, Block $blockReplace, Block $blockClicked, int $face, Vector3 $clickVector, ?Player $player = null) : bool{
+		if(!$blockReplace instanceof Water || !$this->canSurviveOn($blockReplace->getSide(Facing::DOWN))){
+			return false;
+		}
+
+		return parent::place($tx, $item, $blockReplace, $blockClicked, $face, $clickVector, $player);
+	}
+
+	public function onNearbyBlockChange() : void{
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, mt_rand(40, 200));
+	}
+
+	public function onScheduledUpdate() : void{
+		if(!$this->isCoveredWithWater() || !$this->hasValidSupport()){
+			$this->position->getWorld()->useBreakOn($this->position);
+		}
+	}
+
+	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
+		if(!$item instanceof Fertilizer || $this->seagrassType !== SeagrassType::NORMAL){
+			return false;
+		}
+
+		$up = $this->getSide(Facing::UP);
+		if(!$up instanceof Water){
+			return false;
+		}
+
+		$world = $this->position->getWorld();
+		$world->setBlock($this->position, (clone $this)->setSeagrassType(SeagrassType::DOUBLE_BOTTOM));
+		$world->setBlock($up->position, (clone $this)->setSeagrassType(SeagrassType::DOUBLE_TOP));
+		$item->pop();
+
+		return true;
+	}
+
+	public function getDrops(Item $item) : array{
+		if($this->seagrassType === SeagrassType::DOUBLE_TOP){
+			return [];
+		}
+
+		return [$this->asItem()];
+	}
+
+	private function hasValidSupport() : bool{
+		if($this->seagrassType === SeagrassType::DOUBLE_TOP){
+			$down = $this->getSide(Facing::DOWN);
+			return $down instanceof Seagrass && $down->seagrassType === SeagrassType::DOUBLE_BOTTOM;
+		}
+
+		if(!$this->canSurviveOn($this->getSide(Facing::DOWN))){
+			return false;
+		}
+
+		if($this->seagrassType === SeagrassType::DOUBLE_BOTTOM){
+			$up = $this->getSide(Facing::UP);
+			return $up instanceof Seagrass && $up->seagrassType === SeagrassType::DOUBLE_TOP;
+		}
+
+		return true;
+	}
+
+	private function canSurviveOn(Block $block) : bool{
+		return $block->isSolid()
+			&& $block->getTypeId() !== BlockTypeIds::MAGMA
+			&& $block->getTypeId() !== BlockTypeIds::SOUL_SAND;
+	}
+
+	private function isCoveredWithWater() : bool{
+		$world = $this->position->getWorld();
+		foreach($this->position->sides() as $side){
+			if($world->getBlock($side) instanceof Water){
+				return true;
+			}
+		}
+
+		//TODO: check water inside the block itself (not supported on the API yet)
+		return false;
+	}
+}

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -378,6 +378,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 
 		self::register("sea_lantern", fn(BID $id) => new SeaLantern($id, "Sea Lantern", new Info(new BreakInfo(0.3))));
 		self::register("sea_pickle", fn(BID $id) => new SeaPickle($id, "Sea Pickle", new Info(BreakInfo::instant())));
+		self::register("seagrass", fn(BID $id) => new Seagrass($id, "Seagrass", new Info(BreakInfo::instant(ToolType::SHEARS, 1))));
 		self::register("mob_head", fn(BID $id) => new MobHead($id, "Mob Head", new Info(new BreakInfo(1.0), enchantmentTags: [EnchantmentTags::MASK])), TileMobHead::class);
 		self::register("slime", fn(BID $id) => new Slime($id, "Slime Block", new Info(BreakInfo::instant())));
 		self::register("snow", fn(BID $id) => new Snow($id, "Snow Block", new Info(BreakInfo::shovel(0.2, ToolTier::WOOD))));

--- a/src/block/utils/CoveredWithWaterTrait.php
+++ b/src/block/utils/CoveredWithWaterTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block\utils;
+
+use pocketmine\block\Water;
+
+/**
+ * Used by blocks which need water next to them to survive, such as coral and seagrass.
+ */
+trait CoveredWithWaterTrait{
+
+	protected function isCoveredWithWater() : bool{
+		$world = $this->position->getWorld();
+		foreach($this->position->sides() as $vector3){
+			if($world->getBlock($vector3) instanceof Water){
+				return true;
+			}
+		}
+
+		//TODO: check water inside the block itself (not supported on the API yet)
+		return false;
+	}
+}

--- a/src/block/utils/SeagrassType.php
+++ b/src/block/utils/SeagrassType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block\utils;
+
+use pocketmine\utils\LegacyEnumShimTrait;
+
+/**
+ * TODO: These tags need to be removed once we get rid of LegacyEnumShimTrait (PM6)
+ *  These are retained for backwards compatibility only.
+ *
+ * @method static SeagrassType NORMAL()
+ * @method static SeagrassType DOUBLE_TOP()
+ * @method static SeagrassType DOUBLE_BOTTOM()
+ */
+enum SeagrassType{
+	use LegacyEnumShimTrait;
+
+	case NORMAL;
+	case DOUBLE_TOP;
+	case DOUBLE_BOTTOM;
+}

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -80,6 +80,7 @@ use pocketmine\block\RedstoneRepeater;
 use pocketmine\block\RedstoneTorch;
 use pocketmine\block\RespawnAnchor;
 use pocketmine\block\Sapling;
+use pocketmine\block\Seagrass;
 use pocketmine\block\SeaPickle;
 use pocketmine\block\SmallDripleaf;
 use pocketmine\block\SnowLayer;
@@ -104,6 +105,7 @@ use pocketmine\block\utils\LeverFacing;
 use pocketmine\block\utils\MobHeadType;
 use pocketmine\block\utils\MushroomBlockType;
 use pocketmine\block\utils\PoweredByRedstone;
+use pocketmine\block\utils\SeagrassType;
 use pocketmine\block\VanillaBlocks as Blocks;
 use pocketmine\block\Vine;
 use pocketmine\data\bedrock\block\BlockLegacyMetadata;
@@ -435,6 +437,9 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::SANDSTONE(), Ids::SANDSTONE);
 		$reg->mapSimple(Blocks::SCULK(), Ids::SCULK);
 		$reg->mapSimple(Blocks::SEA_LANTERN(), Ids::SEA_LANTERN);
+		$reg->mapModel(Model::create(Blocks::SEAGRASS(), Ids::SEAGRASS)->properties([
+			new ValueFromStringProperty(StateNames::SEA_GRASS_TYPE, ValueMappings::getInstance()->seaGrassType, fn(Seagrass $b) => $b->getSeagrassType(), fn(Seagrass $b, SeagrassType $v) => $b->setSeagrassType($v))
+		]));
 		$reg->mapSimple(Blocks::SHROOMLIGHT(), Ids::SHROOMLIGHT);
 		$reg->mapSimple(Blocks::SHULKER_BOX(), Ids::UNDYED_SHULKER_BOX);
 		$reg->mapSimple(Blocks::SLIME(), Ids::SLIME);

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -437,9 +437,6 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::SANDSTONE(), Ids::SANDSTONE);
 		$reg->mapSimple(Blocks::SCULK(), Ids::SCULK);
 		$reg->mapSimple(Blocks::SEA_LANTERN(), Ids::SEA_LANTERN);
-		$reg->mapModel(Model::create(Blocks::SEAGRASS(), Ids::SEAGRASS)->properties([
-			new ValueFromStringProperty(StateNames::SEA_GRASS_TYPE, ValueMappings::getInstance()->seaGrassType, fn(Seagrass $b) => $b->getSeagrassType(), fn(Seagrass $b, SeagrassType $v) => $b->setSeagrassType($v))
-		]));
 		$reg->mapSimple(Blocks::SHROOMLIGHT(), Ids::SHROOMLIGHT);
 		$reg->mapSimple(Blocks::SHULKER_BOX(), Ids::UNDYED_SHULKER_BOX);
 		$reg->mapSimple(Blocks::SLIME(), Ids::SLIME);
@@ -605,6 +602,10 @@ final class VanillaBlockMappings{
 				new ValueFromIntProperty(StateNames::HUGE_MUSHROOM_BITS, ValueMappings::getInstance()->mushroomBlockType, fn(RedMushroomBlock $b) => $b->getMushroomBlockType(), fn(RedMushroomBlock $b, MushroomBlockType $v) => $b->setMushroomBlockType($v)),
 			]));
 		}
+
+		$reg->mapModel(Model::create(Blocks::SEAGRASS(), Ids::SEAGRASS)->properties([
+			new ValueFromStringProperty(StateNames::SEA_GRASS_TYPE, ValueMappings::getInstance()->seaGrassType, fn(Seagrass $b) => $b->getSeagrassType(), fn(Seagrass $b, SeagrassType $v) => $b->setSeagrassType($v))
+		]));
 
 		$reg->mapModel(Model::create(Blocks::GLOW_LICHEN(), Ids::GLOW_LICHEN)->properties([$commonProperties->multiFacingFlags]));
 		$reg->mapModel(Model::create(Blocks::RESIN_CLUMP(), Ids::RESIN_CLUMP)->properties([$commonProperties->multiFacingFlags]));

--- a/src/data/bedrock/block/convert/property/ValueMappings.php
+++ b/src/data/bedrock/block/convert/property/ValueMappings.php
@@ -34,6 +34,7 @@ use pocketmine\block\utils\FroglightType;
 use pocketmine\block\utils\LeverFacing;
 use pocketmine\block\utils\MobHeadType;
 use pocketmine\block\utils\MushroomBlockType;
+use pocketmine\block\utils\SeagrassType;
 use pocketmine\data\bedrock\block\BlockLegacyMetadata as LegacyMeta;
 use pocketmine\data\bedrock\block\BlockStateStringValues as StringValues;
 use pocketmine\data\bedrock\block\BlockTypeNames as Ids;
@@ -59,6 +60,9 @@ final class ValueMappings{
 	public readonly EnumFromRawStateMap $dripleafState;
 	/** @phpstan-var EnumFromRawStateMap<BellAttachmentType, string> */
 	public readonly EnumFromRawStateMap $bellAttachmentType;
+
+	/** @phpstan-var EnumFromRawStateMap<SeagrassType, string> */
+	public readonly EnumFromRawStateMap $seaGrassType;
 	/** @phpstan-var EnumFromRawStateMap<LeverFacing, string> */
 	public readonly EnumFromRawStateMap $leverFacing;
 
@@ -159,6 +163,11 @@ final class ValueMappings{
 			BellAttachmentType::CEILING => StringValues::ATTACHMENT_HANGING,
 			BellAttachmentType::ONE_WALL => StringValues::ATTACHMENT_SIDE,
 			BellAttachmentType::TWO_WALLS => StringValues::ATTACHMENT_MULTIPLE,
+		});
+		$this->seaGrassType = EnumFromRawStateMap::string(SeagrassType::class, fn(SeagrassType $case) => match ($case) {
+			SeagrassType::NORMAL => StringValues::SEA_GRASS_TYPE_DEFAULT,
+			SeagrassType::DOUBLE_TOP => StringValues::SEA_GRASS_TYPE_DOUBLE_TOP,
+			SeagrassType::DOUBLE_BOTTOM => StringValues::SEA_GRASS_TYPE_DOUBLE_BOT,
 		});
 		$this->leverFacing = EnumFromRawStateMap::string(LeverFacing::class, fn(LeverFacing $case) => match ($case) {
 			LeverFacing::DOWN_AXIS_Z => StringValues::LEVER_DIRECTION_DOWN_NORTH_SOUTH,

--- a/src/data/bedrock/block/convert/property/ValueMappings.php
+++ b/src/data/bedrock/block/convert/property/ValueMappings.php
@@ -60,7 +60,6 @@ final class ValueMappings{
 	public readonly EnumFromRawStateMap $dripleafState;
 	/** @phpstan-var EnumFromRawStateMap<BellAttachmentType, string> */
 	public readonly EnumFromRawStateMap $bellAttachmentType;
-
 	/** @phpstan-var EnumFromRawStateMap<SeagrassType, string> */
 	public readonly EnumFromRawStateMap $seaGrassType;
 	/** @phpstan-var EnumFromRawStateMap<LeverFacing, string> */

--- a/tests/phpunit/block/block_factory_consistency_check.json
+++ b/tests/phpunit/block/block_factory_consistency_check.json
@@ -704,6 +704,7 @@
         "SANDSTONE_STAIRS": 8,
         "SANDSTONE_WALL": 162,
         "SCULK": 1,
+        "SEAGRASS": 3,
         "SEA_LANTERN": 1,
         "SEA_PICKLE": 8,
         "SHROOMLIGHT": 1,


### PR DESCRIPTION
Added the Seagrass block to Altay.

Water detection follows the same approach as the existing Coral block, since Altay does not have proper waterlogging
support yet.

## Changes

### API changes

- Added the `Seagrass` block
- Added `SeagrassType` (NORMAL, DOUBLE_TOP, DOUBLE_BOTTOM)

### Behavioural changes

- Seagrass survives on a solid block (except magma and soul sand) as long as
  there is water adjacent to it
- Bone meal turns a normal seagrass into a double (tall) seagrass

## Backwards compatibility

## Tests

Tested ingame: placing under water, breaking when water/support is removed,
and bone meal growth.