### PR TITLE
feat: added bubble column block

### DIFF
--- a/generated/block/VanillaBlocks.php
+++ b/generated/block/VanillaBlocks.php
@@ -141,6 +141,7 @@ final class VanillaBlocks{
 	private static Wall $_mBRICK_WALL;
 	private static BrownMushroom $_mBROWN_MUSHROOM;
 	private static BrownMushroomBlock $_mBROWN_MUSHROOM_BLOCK;
+	private static BubbleColumn $_mBUBBLE_COLUMN;
 	private static BuddingAmethyst $_mBUDDING_AMETHYST;
 	private static Cactus $_mCACTUS;
 	private static CactusFlower $_mCACTUS_FLOWER;
@@ -1006,6 +1007,7 @@ final class VanillaBlocks{
 			"brick_wall" => fn(Wall $v) => self::$_mBRICK_WALL = $v,
 			"brown_mushroom" => fn(BrownMushroom $v) => self::$_mBROWN_MUSHROOM = $v,
 			"brown_mushroom_block" => fn(BrownMushroomBlock $v) => self::$_mBROWN_MUSHROOM_BLOCK = $v,
+			"bubble_column" => fn(BubbleColumn $v) => self::$_mBUBBLE_COLUMN = $v,
 			"budding_amethyst" => fn(BuddingAmethyst $v) => self::$_mBUDDING_AMETHYST = $v,
 			"cactus" => fn(Cactus $v) => self::$_mCACTUS = $v,
 			"cactus_flower" => fn(CactusFlower $v) => self::$_mCACTUS_FLOWER = $v,
@@ -2277,6 +2279,11 @@ final class VanillaBlocks{
 	public static function BROWN_MUSHROOM_BLOCK() : BrownMushroomBlock{
 		if(!isset(self::$_mBROWN_MUSHROOM_BLOCK)){ self::init(); }
 		return clone self::$_mBROWN_MUSHROOM_BLOCK;
+	}
+
+	public static function BUBBLE_COLUMN() : BubbleColumn{
+		if(!isset(self::$_mBUBBLE_COLUMN)){ self::init(); }
+		return clone self::$_mBUBBLE_COLUMN;
 	}
 
 	public static function BUDDING_AMETHYST() : BuddingAmethyst{

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -888,8 +888,9 @@ final class BlockTypeIds{
 	public const DENY = 10855;
   public const DECORATED_POT = 10856;
 	public const SEAGRASS = 10857;
+	public const BUBBLE_COLUMN = 10858;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10858;
+	public const FIRST_UNUSED_BLOCK_ID = 10859;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/BubbleColumn.php
+++ b/src/block/BubbleColumn.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\SupportType;
+use pocketmine\data\runtime\RuntimeDataDescriber;
+use pocketmine\entity\Entity;
+use pocketmine\item\Item;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\particle\BubbleParticle;
+use pocketmine\world\particle\SplashParticle;
+use function max;
+use function min;
+use function mt_getrandmax;
+use function mt_rand;
+
+class BubbleColumn extends Transparent{
+
+	private const TICK_RATE = 5;
+
+	private const DOWNWARD_MAX_MOTION = -0.3;
+	private const DOWNWARD_MAX_EXIT_MOTION = -0.9;
+	private const DOWNWARD_ACCELERATION = 0.03;
+	private const UPWARD_MIN_MOTION = 0.7;
+	private const UPWARD_MAX_EXIT_MOTION = 1.8;
+	private const UPWARD_ACCELERATION = 0.08;
+	private const UPWARD_EXIT_ACCELERATION = 0.1;
+
+	protected bool $dragDown = false;
+
+	protected function describeBlockOnlyState(RuntimeDataDescriber $w) : void{
+		$w->bool($this->dragDown);
+	}
+
+	public function isDragDown() : bool{
+		return $this->dragDown;
+	}
+
+	/** @return $this */
+	public function setDragDown(bool $dragDown) : self{
+		$this->dragDown = $dragDown;
+		return $this;
+	}
+
+	public function isSolid() : bool{
+		return false;
+	}
+
+	public function canBeReplaced() : bool{
+		return true;
+	}
+
+	public function canBePlacedAt(Block $blockReplace, Vector3 $clickVector, int $face, bool $isClickedBlock) : bool{
+		return false;
+	}
+
+	protected function recalculateCollisionBoxes() : array{
+		return [];
+	}
+
+	public function getSupportType(int $facing) : SupportType{
+		return SupportType::NONE;
+	}
+
+	public function getDropsForCompatibleTool(Item $item) : array{
+		return [];
+	}
+
+	public function isAffectedBySilkTouch() : bool{
+		return false;
+	}
+
+	public function hasEntityCollision() : bool{
+		return true;
+	}
+
+	public function onEntityInside(Entity $entity) : bool{
+		if(!$entity->canBeMovedByCurrents()){
+			return true;
+		}
+
+		$surface = $this->getSide(Facing::UP)->getTypeId() === BlockTypeIds::AIR;
+		if($surface){
+			$this->spawnColumnParticles();
+		}
+
+		if($entity instanceof Player){
+			return true;
+		}
+
+		$motion = $entity->getMotion();
+		$motionY = max($motion->y, self::DOWNWARD_MAX_MOTION);
+
+		if($surface){
+			$motionY = $this->dragDown
+				? max(self::DOWNWARD_MAX_EXIT_MOTION, $motionY - self::DOWNWARD_ACCELERATION)
+				: min(self::UPWARD_MAX_EXIT_MOTION, $motionY + self::UPWARD_EXIT_ACCELERATION);
+		}else{
+			$motionY = $this->dragDown
+				? max(self::DOWNWARD_MAX_MOTION, $motionY - self::DOWNWARD_ACCELERATION)
+				: min(self::UPWARD_MIN_MOTION, $motionY + self::UPWARD_ACCELERATION);
+		}
+
+		$entity->setMotion($motion->withComponents(null, $motionY, null));
+		$entity->resetFallDistance();
+
+		return true;
+	}
+
+	public function onNearbyBlockChange() : void{
+		$this->position->getWorld()->scheduleDelayedBlockUpdate($this->position, self::TICK_RATE);
+	}
+
+	public function onScheduledUpdate() : void{
+		$world = $this->position->getWorld();
+		$down = $this->getSide(Facing::DOWN);
+
+		$stillSupported = match(true){
+			$down instanceof BubbleColumn => $down->dragDown === $this->dragDown,
+			$down->getTypeId() === BlockTypeIds::MAGMA => $this->dragDown,
+			$down->getTypeId() === BlockTypeIds::SOUL_SAND => !$this->dragDown,
+			default => false
+		};
+
+		if(!$stillSupported){
+			$world->setBlock($this->position, VanillaBlocks::WATER());
+			return;
+		}
+
+		$up = $this->getSide(Facing::UP);
+		if($up instanceof Water && $up->isSource()){
+			$world->setBlock($up->position, (clone $this));
+			$world->scheduleDelayedBlockUpdate($up->position, self::TICK_RATE);
+		}
+	}
+
+	private function spawnColumnParticles() : void{
+		$world = $this->position->getWorld();
+		for($i = 0; $i < 2; $i++){
+			$pos = $this->position->add(mt_rand() / mt_getrandmax(), 1 + mt_rand() / mt_getrandmax(), mt_rand() / mt_getrandmax());
+			$world->addParticle($pos, new SplashParticle());
+			$world->addParticle($pos, new BubbleParticle());
+		}
+	}
+}

--- a/src/block/BubbleColumn.php
+++ b/src/block/BubbleColumn.php
@@ -28,16 +28,13 @@ namespace pocketmine\block;
 use pocketmine\block\utils\SupportType;
 use pocketmine\data\runtime\RuntimeDataDescriber;
 use pocketmine\entity\Entity;
+use pocketmine\event\entity\EntityExtinguishEvent;
 use pocketmine\item\Item;
 use pocketmine\math\Facing;
 use pocketmine\math\Vector3;
 use pocketmine\player\Player;
-use pocketmine\world\particle\BubbleParticle;
-use pocketmine\world\particle\SplashParticle;
 use function max;
 use function min;
-use function mt_getrandmax;
-use function mt_rand;
 
 class BubbleColumn extends Transparent{
 
@@ -46,9 +43,9 @@ class BubbleColumn extends Transparent{
 	private const DOWNWARD_MAX_MOTION = -0.3;
 	private const DOWNWARD_MAX_EXIT_MOTION = -0.9;
 	private const DOWNWARD_ACCELERATION = 0.03;
-	private const UPWARD_MIN_MOTION = 0.7;
+	private const UPWARD_MAX_MOTION = 0.7;
 	private const UPWARD_MAX_EXIT_MOTION = 1.8;
-	private const UPWARD_ACCELERATION = 0.08;
+	private const UPWARD_ACCELERATION = 0.06;
 	private const UPWARD_EXIT_ACCELERATION = 0.1;
 
 	protected bool $dragDown = false;
@@ -65,6 +62,10 @@ class BubbleColumn extends Transparent{
 	public function setDragDown(bool $dragDown) : self{
 		$this->dragDown = $dragDown;
 		return $this;
+	}
+
+	public function getLightFilter() : int{
+		return 2;
 	}
 
 	public function isSolid() : bool{
@@ -100,34 +101,30 @@ class BubbleColumn extends Transparent{
 	}
 
 	public function onEntityInside(Entity $entity) : bool{
-		if(!$entity->canBeMovedByCurrents()){
-			return true;
+		//a bubble column replaces a water source, so it has to keep water's effects on entities inside it
+		$entity->resetFallDistance();
+		if($entity->isOnFire()){
+			$entity->extinguish(EntityExtinguishEvent::CAUSE_WATER);
 		}
 
-		$surface = $this->getSide(Facing::UP)->getTypeId() === BlockTypeIds::AIR;
-		if($surface){
-			$this->spawnColumnParticles();
-		}
-
-		if($entity instanceof Player){
+		//players are moved by the client, which already knows how to ride a bubble column - pushing them
+		//from here as well would fight their own movement
+		if($entity instanceof Player || !$entity->canBeMovedByCurrents()){
 			return true;
 		}
 
 		$motion = $entity->getMotion();
-		$motionY = max($motion->y, self::DOWNWARD_MAX_MOTION);
-
-		if($surface){
+		if($this->getSide(Facing::UP)->getTypeId() === BlockTypeIds::AIR){
 			$motionY = $this->dragDown
-				? max(self::DOWNWARD_MAX_EXIT_MOTION, $motionY - self::DOWNWARD_ACCELERATION)
-				: min(self::UPWARD_MAX_EXIT_MOTION, $motionY + self::UPWARD_EXIT_ACCELERATION);
+				? max(self::DOWNWARD_MAX_EXIT_MOTION, $motion->y - self::DOWNWARD_ACCELERATION)
+				: min(self::UPWARD_MAX_EXIT_MOTION, $motion->y + self::UPWARD_EXIT_ACCELERATION);
 		}else{
 			$motionY = $this->dragDown
-				? max(self::DOWNWARD_MAX_MOTION, $motionY - self::DOWNWARD_ACCELERATION)
-				: min(self::UPWARD_MIN_MOTION, $motionY + self::UPWARD_ACCELERATION);
+				? max(self::DOWNWARD_MAX_MOTION, $motion->y - self::DOWNWARD_ACCELERATION)
+				: min(self::UPWARD_MAX_MOTION, $motion->y + self::UPWARD_ACCELERATION);
 		}
 
 		$entity->setMotion($motion->withComponents(null, $motionY, null));
-		$entity->resetFallDistance();
 
 		return true;
 	}
@@ -154,17 +151,8 @@ class BubbleColumn extends Transparent{
 
 		$up = $this->getSide(Facing::UP);
 		if($up instanceof Water && $up->isSource()){
-			$world->setBlock($up->position, (clone $this));
+			$world->setBlock($up->position, VanillaBlocks::BUBBLE_COLUMN()->setDragDown($this->dragDown));
 			$world->scheduleDelayedBlockUpdate($up->position, self::TICK_RATE);
-		}
-	}
-
-	private function spawnColumnParticles() : void{
-		$world = $this->position->getWorld();
-		for($i = 0; $i < 2; $i++){
-			$pos = $this->position->add(mt_rand() / mt_getrandmax(), 1 + mt_rand() / mt_getrandmax(), mt_rand() / mt_getrandmax());
-			$world->addParticle($pos, new SplashParticle());
-			$world->addParticle($pos, new BubbleParticle());
 		}
 	}
 }

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -176,7 +176,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("bricks", fn(BID $id) => new Opaque($id, "Bricks", $bricksBreakInfo));
 
 		self::register("brown_mushroom", fn(BID $id) => new BrownMushroom($id, "Brown Mushroom", new Info(BreakInfo::instant(), [Tags::POTTABLE_PLANTS])));
-		self::register("bubble_column", fn(BID $id) => new BubbleColumn($id, "Bubble Column", new Info(BreakInfo::instant())));
+		self::register("bubble_column", fn(BID $id) => new BubbleColumn($id, "Bubble Column", new Info(BreakInfo::indestructible(500.0))));
 		self::register("cactus", fn(BID $id) => new Cactus($id, "Cactus", new Info(new BreakInfo(0.4), [Tags::POTTABLE_PLANTS])));
 		self::register("cake", fn(BID $id) => new Cake($id, "Cake", new Info(new BreakInfo(0.5))));
 

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -176,6 +176,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("bricks", fn(BID $id) => new Opaque($id, "Bricks", $bricksBreakInfo));
 
 		self::register("brown_mushroom", fn(BID $id) => new BrownMushroom($id, "Brown Mushroom", new Info(BreakInfo::instant(), [Tags::POTTABLE_PLANTS])));
+		self::register("bubble_column", fn(BID $id) => new BubbleColumn($id, "Bubble Column", new Info(BreakInfo::instant())));
 		self::register("cactus", fn(BID $id) => new Cactus($id, "Cactus", new Info(new BreakInfo(0.4), [Tags::POTTABLE_PLANTS])));
 		self::register("cake", fn(BID $id) => new Cake($id, "Cake", new Info(new BreakInfo(0.5))));
 

--- a/src/block/Water.php
+++ b/src/block/Water.php
@@ -27,6 +27,7 @@ namespace pocketmine\block;
 
 use pocketmine\entity\Entity;
 use pocketmine\event\entity\EntityExtinguishEvent;
+use pocketmine\math\Facing;
 use pocketmine\world\sound\BucketEmptyWaterSound;
 use pocketmine\world\sound\BucketFillWaterSound;
 use pocketmine\world\sound\Sound;
@@ -35,6 +36,19 @@ class Water extends Liquid{
 
 	public function getLightFilter() : int{
 		return 2;
+	}
+
+	public function onScheduledUpdate() : void{
+		if($this->isSource()){
+			$down = $this->getSide(Facing::DOWN);
+			$dragDown = $down->getTypeId() === BlockTypeIds::MAGMA;
+			if($dragDown || $down->getTypeId() === BlockTypeIds::SOUL_SAND){
+				$this->position->getWorld()->setBlock($this->position, VanillaBlocks::BUBBLE_COLUMN()->setDragDown($dragDown));
+				return;
+			}
+		}
+
+		parent::onScheduledUpdate();
 	}
 
 	public function getBucketFillSound() : Sound{

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -176,9 +176,6 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::BOOKSHELF(), Ids::BOOKSHELF);
 		$reg->mapSimple(Blocks::BRICKS(), Ids::BRICK_BLOCK);
 		$reg->mapSimple(Blocks::BROWN_MUSHROOM(), Ids::BROWN_MUSHROOM);
-		$reg->mapModel(Model::create(Blocks::BUBBLE_COLUMN(), Ids::BUBBLE_COLUMN)->properties([
-			new BoolProperty(StateNames::DRAG_DOWN, fn(BubbleColumn $b) => $b->isDragDown(), fn(BubbleColumn $b, bool $v) => $b->setDragDown($v))
-		]));
 		$reg->mapSimple(Blocks::BUDDING_AMETHYST(), Ids::BUDDING_AMETHYST);
 		$reg->mapSimple(Blocks::CALCITE(), Ids::CALCITE);
 		$reg->mapSimple(Blocks::CARTOGRAPHY_TABLE(), Ids::CARTOGRAPHY_TABLE);
@@ -1343,6 +1340,9 @@ final class VanillaBlockMappings{
 			BrewingStandSlot::SOUTHWEST => StateNames::BREWING_STAND_SLOT_B_BIT,
 			BrewingStandSlot::NORTHWEST => StateNames::BREWING_STAND_SLOT_C_BIT
 		}, fn(BrewingStand $b) => $b->hasSlot($slot), fn(BrewingStand $b, bool $v) => $b->setSlot($slot, $v)), BrewingStandSlot::cases())));
+		$reg->mapModel(Model::create(Blocks::BUBBLE_COLUMN(), Ids::BUBBLE_COLUMN)->properties([
+			new BoolProperty(StateNames::DRAG_DOWN, fn(BubbleColumn $b) => $b->isDragDown(), fn(BubbleColumn $b, bool $v) => $b->setDragDown($v))
+		]));
 
 		//C
 		$reg->mapModel(Model::create(Blocks::CACTUS(), Ids::CACTUS)->properties([

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -37,6 +37,7 @@ use pocketmine\block\Bell;
 use pocketmine\block\BigDripleafHead;
 use pocketmine\block\Block;
 use pocketmine\block\BrewingStand;
+use pocketmine\block\BubbleColumn;
 use pocketmine\block\Cactus;
 use pocketmine\block\Cake;
 use pocketmine\block\Candle;
@@ -175,6 +176,9 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::BOOKSHELF(), Ids::BOOKSHELF);
 		$reg->mapSimple(Blocks::BRICKS(), Ids::BRICK_BLOCK);
 		$reg->mapSimple(Blocks::BROWN_MUSHROOM(), Ids::BROWN_MUSHROOM);
+		$reg->mapModel(Model::create(Blocks::BUBBLE_COLUMN(), Ids::BUBBLE_COLUMN)->properties([
+			new BoolProperty(StateNames::DRAG_DOWN, fn(BubbleColumn $b) => $b->isDragDown(), fn(BubbleColumn $b, bool $v) => $b->setDragDown($v))
+		]));
 		$reg->mapSimple(Blocks::BUDDING_AMETHYST(), Ids::BUDDING_AMETHYST);
 		$reg->mapSimple(Blocks::CALCITE(), Ids::CALCITE);
 		$reg->mapSimple(Blocks::CARTOGRAPHY_TABLE(), Ids::CARTOGRAPHY_TABLE);

--- a/tests/phpunit/block/BlockTest.php
+++ b/tests/phpunit/block/BlockTest.php
@@ -114,6 +114,7 @@ class BlockTest extends TestCase{
 			BlockTypeNames::FLOWING_WATER,
 			BlockTypeNames::LAVA,
 			BlockTypeNames::FLOWING_LAVA,
+			BlockTypeNames::BUBBLE_COLUMN, //the table claims it's instantly breakable, but like water it can't be targeted at all
 			BlockTypeNames::MANGROVE_LOG, //For some reason ONLY this wood block has blast resistance 2 instead of 10...
 			BlockTypeNames::BORDER_BLOCK, //the table claims it's breakable, but it's a creative-only block which can't be destroyed by any means
 		], true);

--- a/tests/phpunit/block/block_factory_consistency_check.json
+++ b/tests/phpunit/block/block_factory_consistency_check.json
@@ -101,6 +101,7 @@
         "BRICK_WALL": 162,
         "BROWN_MUSHROOM": 1,
         "BROWN_MUSHROOM_BLOCK": 11,
+        "BUBBLE_COLUMN": 2,
         "BUDDING_AMETHYST": 1,
         "CACTUS": 16,
         "CACTUS_FLOWER": 1,


### PR DESCRIPTION
Added the Bubble Column block to Altay.

Water automatically turns into a bubble column when it settles as a source
block on top of magma (upward column) or soul sand (downward column).

## Changes

### API changes

None

### Behavioural changes

- `Water::onScheduledUpdate()` now checks for magma/soul sand below and
  converts to a bubble column when found

## Backwards compatibility

## Tests

Tested ingame: column formation over magma and soul sand;, entities and items being pushed, an
column reverting to water when the support block is removed.