### PR TITLE
Feat: add honey block

### DIFF
--- a/generated/block/VanillaBlocks.php
+++ b/generated/block/VanillaBlocks.php
@@ -488,6 +488,7 @@ final class VanillaBlocks{
 	private static HardenedGlassPane $_mHARDENED_GLASS_PANE;
 	private static HayBale $_mHAY_BALE;
 	private static Opaque $_mHONEYCOMB;
+	private static HoneyBlock $_mHONEY_BLOCK;
 	private static Hopper $_mHOPPER;
 	private static Ice $_mICE;
 	private static InfestedStone $_mINFESTED_CHISELED_STONE_BRICK;
@@ -1354,6 +1355,7 @@ final class VanillaBlocks{
 			"hardened_glass_pane" => fn(HardenedGlassPane $v) => self::$_mHARDENED_GLASS_PANE = $v,
 			"hay_bale" => fn(HayBale $v) => self::$_mHAY_BALE = $v,
 			"honeycomb" => fn(Opaque $v) => self::$_mHONEYCOMB = $v,
+			"honey_block" => fn(HoneyBlock $v) => self::$_mHONEY_BLOCK = $v,
 			"hopper" => fn(Hopper $v) => self::$_mHOPPER = $v,
 			"ice" => fn(Ice $v) => self::$_mICE = $v,
 			"infested_chiseled_stone_brick" => fn(InfestedStone $v) => self::$_mINFESTED_CHISELED_STONE_BRICK = $v,
@@ -4014,6 +4016,11 @@ final class VanillaBlocks{
 	public static function HONEYCOMB() : Opaque{
 		if(!isset(self::$_mHONEYCOMB)){ self::init(); }
 		return clone self::$_mHONEYCOMB;
+	}
+
+	public static function HONEY_BLOCK() : HoneyBlock{
+		if(!isset(self::$_mHONEY_BLOCK)){ self::init(); }
+		return clone self::$_mHONEY_BLOCK;
 	}
 
 	public static function HOPPER() : Hopper{

--- a/src/block/Block.php
+++ b/src/block/Block.php
@@ -899,6 +899,13 @@ class Block{
 	}
 
 	/**
+	 * Returns the multiplier applied to fall damage taken from landing on this block.
+	 */
+	public function getFallDamageMultiplier() : float{
+		return 1.0;
+	}
+
+	/**
 	 * Called when a projectile collides with one of this block's collision boxes.
 	 */
 	public function onProjectileHit(Projectile $projectile, RayTraceResult $hitResult) : void{

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -889,8 +889,9 @@ final class BlockTypeIds{
   public const DECORATED_POT = 10856;
 	public const SEAGRASS = 10857;
 	public const BUBBLE_COLUMN = 10858;
+	public const HONEY_BLOCK = 10859;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10859;
+	public const FIRST_UNUSED_BLOCK_ID = 10860;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/HoneyBlock.php
+++ b/src/block/HoneyBlock.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\entity\Entity;
+use pocketmine\math\AxisAlignedBB;
+use pocketmine\math\Facing;
+use pocketmine\player\Player;
+use function abs;
+
+class HoneyBlock extends Opaque{
+
+	private const SLIDE_INSET = 0.1;
+	private const SLIDE_MOTION = -0.05;
+
+	public function getLightFilter() : int{
+		return 1;
+	}
+
+	public function getFrictionFactor() : float{
+		return 0.8;
+	}
+
+	public function getFallDamageMultiplier() : float{
+		return 0.2;
+	}
+
+	public function hasEntityCollision() : bool{
+		return true;
+	}
+
+	protected function recalculateCollisionBoxes() : array{
+		return [AxisAlignedBB::one()->trim(Facing::WEST, self::SLIDE_INSET)->trim(Facing::EAST, self::SLIDE_INSET)->trim(Facing::NORTH, self::SLIDE_INSET)->trim(Facing::SOUTH, self::SLIDE_INSET)];
+	}
+
+	public function onEntityInside(Entity $entity) : bool{
+		$motion = $entity->getMotion();
+		if($entity->isOnGround() || $motion->y > 0.08 || ($entity instanceof Player && $entity->isFlying())){
+			return true;
+		}
+
+		$center = $this->position->add(0.5, 0, 0.5);
+		$position = $entity->getPosition();
+		$width = self::SLIDE_INSET + $entity->getSize()->getWidth() / 2;
+
+		$ex = abs($center->x - $position->x);
+		$ez = abs($center->z - $position->z);
+		if($ex <= $width && $ez <= $width){
+			return true;
+		}
+
+		$newMotionY = self::SLIDE_MOTION;
+		$newMotionX = $motion->x;
+		$newMotionZ = $motion->z;
+		if($motion->y < -0.13){
+			$multiplier = self::SLIDE_MOTION / $motion->y;
+			$newMotionX *= $multiplier;
+			$newMotionZ *= $multiplier;
+		}
+
+		$entity->setMotion($motion->withComponents($newMotionX, $newMotionY, $newMotionZ));
+		$entity->resetFallDistance();
+
+		return true;
+	}
+}

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -273,6 +273,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("hardened_glass", fn(BID $id) => new HardenedGlass($id, "Hardened Glass", $hardenedGlassBreakInfo));
 		self::register("hardened_glass_pane", fn(BID $id) => new HardenedGlassPane($id, "Hardened Glass Pane", $hardenedGlassBreakInfo));
 		self::register("hay_bale", fn(BID $id) => new HayBale($id, "Hay Bale", new Info(new BreakInfo(0.5))));
+		self::register("honey_block", fn(BID $id) => new HoneyBlock($id, "Honey Block", new Info(BreakInfo::instant())));
 		self::register("hopper", fn(BID $id) => new Hopper($id, "Hopper", new Info(BreakInfo::pickaxe(3.0, ToolTier::WOOD, 24.0))), TileHopper::class);
 		self::register("ice", fn(BID $id) => new Ice($id, "Ice", new Info(BreakInfo::pickaxe(0.5))));
 

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -369,6 +369,7 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::HARDENED_CLAY(), Ids::HARDENED_CLAY);
 		$reg->mapSimple(Blocks::HARDENED_GLASS(), Ids::HARD_GLASS);
 		$reg->mapSimple(Blocks::HARDENED_GLASS_PANE(), Ids::HARD_GLASS_PANE);
+		$reg->mapSimple(Blocks::HONEY_BLOCK(), Ids::HONEY_BLOCK);
 		$reg->mapSimple(Blocks::HONEYCOMB(), Ids::HONEYCOMB_BLOCK);
 		$reg->mapSimple(Blocks::ICE(), Ids::ICE);
 		$reg->mapSimple(Blocks::INFESTED_CHISELED_STONE_BRICK(), Ids::INFESTED_CHISELED_STONE_BRICKS);

--- a/src/entity/Living.php
+++ b/src/entity/Living.php
@@ -395,7 +395,7 @@ abstract class Living extends Entity{
 		}
 		$newVerticalVelocity = $fallBlock->onEntityLand($this);
 
-		$damage = $this->calculateFallDamage($this->fallDistance);
+		$damage = $this->calculateFallDamage($this->fallDistance) * $fallBlock->getFallDamageMultiplier();
 		if($damage > 0){
 			$ev = new EntityDamageEvent($this, EntityDamageEvent::CAUSE_FALL, $damage);
 			$this->attack($ev);

--- a/tests/phpunit/block/block_factory_consistency_check.json
+++ b/tests/phpunit/block/block_factory_consistency_check.json
@@ -448,6 +448,7 @@
         "HARDENED_GLASS_PANE": 1,
         "HAY_BALE": 3,
         "HONEYCOMB": 1,
+        "HONEY_BLOCK": 1,
         "HOPPER": 10,
         "ICE": 1,
         "INFESTED_CHISELED_STONE_BRICK": 1,


### PR DESCRIPTION
Added the Honey Block to Altay.

## Changes

### API changes

- Added the `HoneyBlock` block
- Added `Block::getFallDamageMultiplier()`, used by `Living::onHitGround()` to
  scale fall damage based on the block landed on

### Behavioural changes

i think none.

## Backwards compatibility

## Tests

Tested ingame: reduced fall damage when landing on top.