### PR TITLE
feat: implement moss block

### DIFF
--- a/generated/block/VanillaBlocks.php
+++ b/generated/block/VanillaBlocks.php
@@ -576,6 +576,7 @@ final class VanillaBlocks{
 	private static Slab $_mMOSSY_STONE_BRICK_SLAB;
 	private static Stair $_mMOSSY_STONE_BRICK_STAIRS;
 	private static Wall $_mMOSSY_STONE_BRICK_WALL;
+	private static MossBlock $_mMOSS_BLOCK;
 	private static Opaque $_mMUD;
 	private static SimplePillar $_mMUDDY_MANGROVE_ROOTS;
 	private static Opaque $_mMUD_BRICKS;
@@ -1443,6 +1444,7 @@ final class VanillaBlocks{
 			"mossy_stone_brick_slab" => fn(Slab $v) => self::$_mMOSSY_STONE_BRICK_SLAB = $v,
 			"mossy_stone_brick_stairs" => fn(Stair $v) => self::$_mMOSSY_STONE_BRICK_STAIRS = $v,
 			"mossy_stone_brick_wall" => fn(Wall $v) => self::$_mMOSSY_STONE_BRICK_WALL = $v,
+			"moss_block" => fn(MossBlock $v) => self::$_mMOSS_BLOCK = $v,
 			"mud" => fn(Opaque $v) => self::$_mMUD = $v,
 			"muddy_mangrove_roots" => fn(SimplePillar $v) => self::$_mMUDDY_MANGROVE_ROOTS = $v,
 			"mud_bricks" => fn(Opaque $v) => self::$_mMUD_BRICKS = $v,
@@ -4456,6 +4458,11 @@ final class VanillaBlocks{
 	public static function MOSSY_STONE_BRICK_WALL() : Wall{
 		if(!isset(self::$_mMOSSY_STONE_BRICK_WALL)){ self::init(); }
 		return clone self::$_mMOSSY_STONE_BRICK_WALL;
+	}
+
+	public static function MOSS_BLOCK() : MossBlock{
+		if(!isset(self::$_mMOSS_BLOCK)){ self::init(); }
+		return clone self::$_mMOSS_BLOCK;
 	}
 
 	public static function MUD() : Opaque{

--- a/src/block/Azalea.php
+++ b/src/block/Azalea.php
@@ -80,9 +80,9 @@ class Azalea extends Flowable{
 	}
 
 	private function canBeSupportedAt(Block $block) : bool{
-		//TODO: Moss block
 		$supportBlock = $block->getSide(Facing::DOWN);
 		return $supportBlock->getTypeId() === BlockTypeIds::CLAY ||
+			$supportBlock->getTypeId() === BlockTypeIds::MOSS_BLOCK ||
 			$supportBlock->hasTypeTag(BlockTypeTags::DIRT) ||
 			$supportBlock->hasTypeTag(BlockTypeTags::MUD);
 	}

--- a/src/block/BlockTypeIds.php
+++ b/src/block/BlockTypeIds.php
@@ -890,8 +890,9 @@ final class BlockTypeIds{
 	public const SEAGRASS = 10857;
 	public const BUBBLE_COLUMN = 10858;
 	public const HONEY_BLOCK = 10859;
+	public const MOSS_BLOCK = 10860;
 
-	public const FIRST_UNUSED_BLOCK_ID = 10860;
+	public const FIRST_UNUSED_BLOCK_ID = 10861;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_BLOCK_ID;
 

--- a/src/block/MossBlock.php
+++ b/src/block/MossBlock.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\block;
+
+use pocketmine\block\utils\DirtType;
+use pocketmine\item\Fertilizer;
+use pocketmine\item\Item;
+use pocketmine\math\Facing;
+use pocketmine\math\Vector3;
+use pocketmine\player\Player;
+use pocketmine\world\particle\HappyVillagerParticle;
+use pocketmine\world\World;
+use function abs;
+use function mt_getrandmax;
+use function mt_rand;
+
+class MossBlock extends Opaque{
+
+	private const SPREAD_RADIUS = 3;
+	private const SPREAD_VERTICAL_RANGE = 5;
+
+	public function onInteract(Item $item, int $face, Vector3 $clickVector, ?Player $player = null, array &$returnedItems = []) : bool{
+		if(!$item instanceof Fertilizer || $face !== Facing::UP){
+			return false;
+		}
+
+		$world = $this->position->getWorld();
+		$this->spreadMoss($world);
+		$this->populateFlora($world);
+		$world->addParticle($this->position->add(0.5, 1.5, 0.5), new HappyVillagerParticle());
+		$item->pop();
+
+		return true;
+	}
+
+	private function spreadMoss(World $world) : void{
+		$bx = $this->position->getFloorX();
+		$by = $this->position->getFloorY();
+		$bz = $this->position->getFloorZ();
+
+		for($x = $bx - self::SPREAD_RADIUS; $x <= $bx + self::SPREAD_RADIUS; $x++){
+			for($z = $bz - self::SPREAD_RADIUS; $z <= $bz + self::SPREAD_RADIUS; $z++){
+				for($y = $by + self::SPREAD_VERTICAL_RANGE; $y >= $by - self::SPREAD_VERTICAL_RANGE; $y--){
+					if(!$world->isInWorld($x, $y, $z)){
+						continue;
+					}
+
+					$block = $world->getBlockAt($x, $y, $z);
+					if(!$this->canConvertToMoss($block)){
+						continue;
+					}
+
+					$isNearOrigin = abs($x - $bx) < self::SPREAD_RADIUS && abs($z - $bz) < self::SPREAD_RADIUS;
+					if((mt_rand() / mt_getrandmax()) < 0.6 || $isNearOrigin){
+						$world->setBlockAt($x, $y, $z, VanillaBlocks::MOSS_BLOCK());
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	private function populateFlora(World $world) : void{
+		$bx = $this->position->getFloorX();
+		$by = $this->position->getFloorY();
+		$bz = $this->position->getFloorZ();
+
+		for($x = $bx - self::SPREAD_RADIUS; $x <= $bx + self::SPREAD_RADIUS; $x++){
+			for($z = $bz - self::SPREAD_RADIUS; $z <= $bz + self::SPREAD_RADIUS; $z++){
+				for($y = $by + self::SPREAD_VERTICAL_RANGE; $y >= $by - self::SPREAD_VERTICAL_RANGE; $y--){
+					if(!$world->isInWorld($x, $y, $z) || !$world->isInWorld($x, $y - 1, $z)){
+						continue;
+					}
+
+					if($world->getBlockAt($x, $y, $z)->getTypeId() !== BlockTypeIds::AIR){
+						continue;
+					}
+
+					$below = $world->getBlockAt($x, $y - 1, $z);
+					if(!$below->isSolid()){
+						continue;
+					}
+
+					if(!$this->canGrowPlantOn($below)){
+						break;
+					}
+
+					$this->populateColumn($world, $x, $y, $z);
+					break;
+				}
+			}
+		}
+	}
+
+	private function populateColumn(World $world, int $x, int $y, int $z) : void{
+		$roll = mt_rand() / mt_getrandmax();
+
+		if($roll < 0.3125){
+			$world->setBlockAt($x, $y, $z, VanillaBlocks::TALL_GRASS());
+			return;
+		}
+
+		if($roll < 0.46875){
+			//vanilla places moss carpet here, which Altay does not implement yet
+			return;
+		}
+
+		if($roll < 0.53125){
+			if($world->isInWorld($x, $y + 1, $z) && $world->getBlockAt($x, $y + 1, $z)->getTypeId() === BlockTypeIds::AIR){
+				$world->setBlockAt($x, $y, $z, (clone VanillaBlocks::LARGE_FERN())->setTop(false));
+				$world->setBlockAt($x, $y + 1, $z, (clone VanillaBlocks::LARGE_FERN())->setTop(true));
+			}else{
+				$world->setBlockAt($x, $y, $z, VanillaBlocks::TALL_GRASS());
+			}
+			return;
+		}
+
+		if($roll < 0.575){
+			$world->setBlockAt($x, $y, $z, VanillaBlocks::AZALEA());
+			return;
+		}
+
+		if($roll < 0.6){
+			$world->setBlockAt($x, $y, $z, VanillaBlocks::FLOWERING_AZALEA());
+		}
+	}
+
+	private function canConvertToMoss(Block $block) : bool{
+		if($block instanceof Dirt){
+			return $block->getDirtType() !== DirtType::COARSE;
+		}
+
+		return match($block->getTypeId()){
+			BlockTypeIds::GRASS, BlockTypeIds::STONE, BlockTypeIds::MYCELIUM, BlockTypeIds::DEEPSLATE, BlockTypeIds::TUFF => true,
+			default => false
+		};
+	}
+
+	private function canGrowPlantOn(Block $block) : bool{
+		if($block instanceof Dirt){
+			return $block->getDirtType() !== DirtType::COARSE;
+		}
+
+		return match($block->getTypeId()){
+			BlockTypeIds::GRASS, BlockTypeIds::PODZOL, BlockTypeIds::FARMLAND, BlockTypeIds::MYCELIUM, BlockTypeIds::MOSS_BLOCK => true,
+			default => false
+		};
+	}
+}

--- a/src/block/VanillaBlocksInputs.php
+++ b/src/block/VanillaBlocksInputs.php
@@ -310,6 +310,7 @@ final class VanillaBlocksInputs extends RegistrySource{
 		self::register("melon", fn(BID $id) => new Melon($id, "Melon Block", new Info(BreakInfo::axe(1.0))));
 		self::register("melon_stem", fn(BID $id) => new MelonStem($id, "Melon Stem", new Info(BreakInfo::instant())));
 		self::register("monster_spawner", fn(BID $id) => new MonsterSpawner($id, "Monster Spawner", new Info(BreakInfo::pickaxe(5.0, ToolTier::WOOD))), TileMonsterSpawner::class);
+		self::register("moss_block", fn(BID $id) => new MossBlock($id, "Moss Block", new Info(new BreakInfo(0.1, ToolType::HOE))));
 		self::register("mycelium", fn(BID $id) => new Mycelium($id, "Mycelium", new Info(BreakInfo::shovel(0.6), [Tags::DIRT])));
 
 		$netherBrickBreakInfo = new Info(BreakInfo::pickaxe(2.0, ToolTier::WOOD, 30.0));

--- a/src/data/bedrock/block/convert/VanillaBlockMappings.php
+++ b/src/data/bedrock/block/convert/VanillaBlockMappings.php
@@ -393,6 +393,7 @@ final class VanillaBlockMappings{
 		$reg->mapSimple(Blocks::MANGROVE_ROOTS(), Ids::MANGROVE_ROOTS);
 		$reg->mapSimple(Blocks::MELON(), Ids::MELON_BLOCK);
 		$reg->mapSimple(Blocks::MONSTER_SPAWNER(), Ids::MOB_SPAWNER);
+		$reg->mapSimple(Blocks::MOSS_BLOCK(), Ids::MOSS_BLOCK);
 		$reg->mapSimple(Blocks::MOSSY_COBBLESTONE(), Ids::MOSSY_COBBLESTONE);
 		$reg->mapSimple(Blocks::MOSSY_STONE_BRICKS(), Ids::MOSSY_STONE_BRICKS);
 		$reg->mapSimple(Blocks::MUD(), Ids::MUD);

--- a/tests/phpunit/block/block_factory_consistency_check.json
+++ b/tests/phpunit/block/block_factory_consistency_check.json
@@ -536,6 +536,7 @@
         "MOSSY_STONE_BRICK_SLAB": 3,
         "MOSSY_STONE_BRICK_STAIRS": 8,
         "MOSSY_STONE_BRICK_WALL": 162,
+        "MOSS_BLOCK": 1,
         "MUD": 1,
         "MUDDY_MANGROVE_ROOTS": 3,
         "MUD_BRICKS": 1,


### PR DESCRIPTION
Added the Moss Block to Altay, along with its bone meal spreading behaviour.

This PR does not implement moss carpet, since it doesn't exist in Altay yet.


## Changes

### API changes

- Added the `MossBlock` block

### Behavioural changes

- `Azalea::canBeSupportedAt()` now accepts moss block as valid ground (there was a `//TODO: Moss block` in the code) that made
  azaleas break immediately when grown on moss

## Backwards compatibility

## Tests

Tested ingame: bone meal spreading moss to nearby dirt/grass/stone, growing
tall grass/large ferns/azaleas on top.