### PR TITLE
feat: Implemented crossbow with multishot, piercing and quick charge

### DIFF
--- a/generated/item/VanillaItems.php
+++ b/generated/item/VanillaItems.php
@@ -147,6 +147,7 @@ final class VanillaItems{
 	private static CoralFan $_mCORAL_FAN;
 	private static HangingSign $_mCRIMSON_HANGING_SIGN;
 	private static ItemBlockWallOrFloor $_mCRIMSON_SIGN;
+	private static Crossbow $_mCROSSBOW;
 	private static Boat $_mDARK_OAK_BOAT;
 	private static HangingSign $_mDARK_OAK_HANGING_SIGN;
 	private static ItemBlockWallOrFloor $_mDARK_OAK_SIGN;
@@ -521,6 +522,7 @@ final class VanillaItems{
 			"coral_fan" => fn(CoralFan $v) => self::$_mCORAL_FAN = $v,
 			"crimson_hanging_sign" => fn(HangingSign $v) => self::$_mCRIMSON_HANGING_SIGN = $v,
 			"crimson_sign" => fn(ItemBlockWallOrFloor $v) => self::$_mCRIMSON_SIGN = $v,
+			"crossbow" => fn(Crossbow $v) => self::$_mCROSSBOW = $v,
 			"dark_oak_boat" => fn(Boat $v) => self::$_mDARK_OAK_BOAT = $v,
 			"dark_oak_hanging_sign" => fn(HangingSign $v) => self::$_mDARK_OAK_HANGING_SIGN = $v,
 			"dark_oak_sign" => fn(ItemBlockWallOrFloor $v) => self::$_mDARK_OAK_SIGN = $v,
@@ -1325,6 +1327,11 @@ final class VanillaItems{
 	public static function CRIMSON_SIGN() : ItemBlockWallOrFloor{
 		if(!isset(self::$_mCRIMSON_SIGN)){ self::init(); }
 		return clone self::$_mCRIMSON_SIGN;
+	}
+
+	public static function CROSSBOW() : Crossbow{
+		if(!isset(self::$_mCROSSBOW)){ self::init(); }
+		return clone self::$_mCROSSBOW;
 	}
 
 	public static function DARK_OAK_BOAT() : Boat{

--- a/generated/item/enchantment/VanillaEnchantments.php
+++ b/generated/item/enchantment/VanillaEnchantments.php
@@ -53,10 +53,13 @@ final class VanillaEnchantments{
 	private static KnockbackEnchantment $_mKNOCKBACK;
 	private static Enchantment $_mLUNGE;
 	private static Enchantment $_mMENDING;
+	private static Enchantment $_mMULTISHOT;
+	private static Enchantment $_mPIERCING;
 	private static Enchantment $_mPOWER;
 	private static ProtectionEnchantment $_mPROJECTILE_PROTECTION;
 	private static ProtectionEnchantment $_mPROTECTION;
 	private static Enchantment $_mPUNCH;
+	private static Enchantment $_mQUICK_CHARGE;
 	private static Enchantment $_mRESPIRATION;
 	private static SharpnessEnchantment $_mSHARPNESS;
 	private static Enchantment $_mSILK_TOUCH;
@@ -114,10 +117,13 @@ final class VanillaEnchantments{
 			"KNOCKBACK" => fn(KnockbackEnchantment $v) => self::$_mKNOCKBACK = $v,
 			"LUNGE" => fn(Enchantment $v) => self::$_mLUNGE = $v,
 			"MENDING" => fn(Enchantment $v) => self::$_mMENDING = $v,
+			"MULTISHOT" => fn(Enchantment $v) => self::$_mMULTISHOT = $v,
+			"PIERCING" => fn(Enchantment $v) => self::$_mPIERCING = $v,
 			"POWER" => fn(Enchantment $v) => self::$_mPOWER = $v,
 			"PROJECTILE_PROTECTION" => fn(ProtectionEnchantment $v) => self::$_mPROJECTILE_PROTECTION = $v,
 			"PROTECTION" => fn(ProtectionEnchantment $v) => self::$_mPROTECTION = $v,
 			"PUNCH" => fn(Enchantment $v) => self::$_mPUNCH = $v,
+			"QUICK_CHARGE" => fn(Enchantment $v) => self::$_mQUICK_CHARGE = $v,
 			"RESPIRATION" => fn(Enchantment $v) => self::$_mRESPIRATION = $v,
 			"SHARPNESS" => fn(SharpnessEnchantment $v) => self::$_mSHARPNESS = $v,
 			"SILK_TOUCH" => fn(Enchantment $v) => self::$_mSILK_TOUCH = $v,
@@ -239,6 +245,16 @@ final class VanillaEnchantments{
 		return self::$_mMENDING;
 	}
 
+	public static function MULTISHOT() : Enchantment{
+		if(!isset(self::$_mMULTISHOT)){ self::init(); }
+		return self::$_mMULTISHOT;
+	}
+
+	public static function PIERCING() : Enchantment{
+		if(!isset(self::$_mPIERCING)){ self::init(); }
+		return self::$_mPIERCING;
+	}
+
 	public static function POWER() : Enchantment{
 		if(!isset(self::$_mPOWER)){ self::init(); }
 		return self::$_mPOWER;
@@ -257,6 +273,11 @@ final class VanillaEnchantments{
 	public static function PUNCH() : Enchantment{
 		if(!isset(self::$_mPUNCH)){ self::init(); }
 		return self::$_mPUNCH;
+	}
+
+	public static function QUICK_CHARGE() : Enchantment{
+		if(!isset(self::$_mQUICK_CHARGE)){ self::init(); }
+		return self::$_mQUICK_CHARGE;
 	}
 
 	public static function RESPIRATION() : Enchantment{

--- a/src/data/bedrock/EnchantmentIdMap.php
+++ b/src/data/bedrock/EnchantmentIdMap.php
@@ -67,6 +67,10 @@ final class EnchantmentIdMap{
 
 		$this->register(EnchantmentIds::VANISHING, VanillaEnchantments::VANISHING());
 
+		$this->register(EnchantmentIds::MULTISHOT, VanillaEnchantments::MULTISHOT());
+		$this->register(EnchantmentIds::PIERCING, VanillaEnchantments::PIERCING());
+		$this->register(EnchantmentIds::QUICK_CHARGE, VanillaEnchantments::QUICK_CHARGE());
+
 		$this->register(EnchantmentIds::SWIFT_SNEAK, VanillaEnchantments::SWIFT_SNEAK());
 
 		$this->register(EnchantmentIds::FROST_WALKER, VanillaEnchantments::FROST_WALKER());

--- a/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
+++ b/src/data/bedrock/item/ItemSerializerDeserializerRegistrar.php
@@ -240,6 +240,7 @@ final class ItemSerializerDeserializerRegistrar{
 		$this->map1to1Item(Ids::COPPER_SWORD, Items::COPPER_SWORD());
 		$this->map1to1Item(Ids::CRIMSON_HANGING_SIGN, Items::CRIMSON_HANGING_SIGN());
 		$this->map1to1Item(Ids::CRIMSON_SIGN, Items::CRIMSON_SIGN());
+		$this->map1to1Item(Ids::CROSSBOW, Items::CROSSBOW());
 		$this->map1to1Item(Ids::DARK_OAK_BOAT, Items::DARK_OAK_BOAT());
 		$this->map1to1Item(Ids::DARK_OAK_HANGING_SIGN, Items::DARK_OAK_HANGING_SIGN());
 		$this->map1to1Item(Ids::DARK_OAK_SIGN, Items::DARK_OAK_SIGN());

--- a/src/entity/object/CrossbowFireworkRocket.php
+++ b/src/entity/object/CrossbowFireworkRocket.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\entity\object;
+
+use pocketmine\entity\Living;
+
+class CrossbowFireworkRocket extends FireworkRocket{
+
+	/**
+	 * Ticks during which the rocket cannot hit the entity which shot it, so that it doesn't explode in its face.
+	 */
+	private const OWNER_IMMUNITY_TICKS = 2;
+
+	protected function tickFlight() : void{
+		//unlike a rocket launched from the ground, this one flies straight towards where the crossbow was aimed at
+	}
+
+	protected function entityBaseTick(int $tickDiff = 1) : bool{
+		$hasUpdate = parent::entityBaseTick($tickDiff);
+
+		if(!$this->isFlaggedForDespawn() && $this->hitEntity() !== null){
+			$this->flagForDespawn();
+			$this->explode();
+		}
+
+		return $hasUpdate;
+	}
+
+	private function hitEntity() : ?Living{
+		$owningEntityId = $this->getOwningEntityId();
+		foreach($this->getWorld()->getCollidingEntities($this->boundingBox, $this) as $entity){
+			if(!$entity instanceof Living){
+				continue;
+			}
+
+			if($entity->getId() === $owningEntityId && $this->ticksLived <= self::OWNER_IMMUNITY_TICKS){
+				continue;
+			}
+
+			return $entity;
+		}
+
+		return null;
+	}
+}

--- a/src/entity/projectile/Arrow.php
+++ b/src/entity/projectile/Arrow.php
@@ -43,6 +43,7 @@ use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
 use pocketmine\player\Player;
 use pocketmine\world\sound\ArrowHitSound;
 use function ceil;
+use function count;
 use function mt_rand;
 use function sqrt;
 
@@ -54,6 +55,11 @@ class Arrow extends Projectile{
 	public const PICKUP_ANY = 1;
 	public const PICKUP_CREATIVE = 2;
 
+	/**
+	 * Speed kept by a piercing arrow after going through an entity.
+	 */
+	private const PIERCING_SPEED_MULTIPLIER = 0.99;
+
 	private const TAG_PICKUP = "pickup"; //TAG_Byte
 	public const TAG_CRIT = "crit"; //TAG_Byte
 	private const TAG_LIFE = "life"; //TAG_Short
@@ -63,6 +69,15 @@ class Arrow extends Projectile{
 	protected float $punchKnockback = 0.0;
 	protected int $collideTicks = 0;
 	protected bool $critical = false;
+	protected int $piercing = 0;
+
+	/**
+	 * Entities the arrow already went through, so that it doesn't damage them again on the next tick.
+	 *
+	 * @var true[]
+	 * @phpstan-var array<int, true>
+	 */
+	protected array $piercedEntities = [];
 
 	public function __construct(Location $location, ?Entity $shootingEntity, bool $critical, ?CompoundTag $nbt = null){
 		parent::__construct($location, $shootingEntity, $nbt);
@@ -147,8 +162,38 @@ class Arrow extends Projectile{
 		$this->broadcastAnimation(new ArrowShakeAnimation($this, 7));
 	}
 
+	/**
+	 * Returns how many entities the arrow can go through before stopping.
+	 */
+	public function getPiercing() : int{
+		return $this->piercing;
+	}
+
+	public function setPiercing(int $piercing) : void{
+		if($piercing < 0){
+			throw new \InvalidArgumentException("Piercing must not be negative");
+		}
+		$this->piercing = $piercing;
+	}
+
+	public function canCollideWith(Entity $entity) : bool{
+		return !isset($this->piercedEntities[$entity->getId()]) && parent::canCollideWith($entity);
+	}
+
+	protected function despawnsOnEntityHit() : bool{
+		return count($this->piercedEntities) > $this->piercing;
+	}
+
 	protected function onHitEntity(Entity $entityHit, RayTraceResult $hitResult) : void{
+		$this->piercedEntities[$entityHit->getId()] = true;
+
 		parent::onHitEntity($entityHit, $hitResult);
+
+		if(!$this->isFlaggedForDespawn()){
+			//without this the projectile code would zero the motion, stopping the arrow inside the entity it just went through
+			$this->motion = $this->motion->multiply(self::PIERCING_SPEED_MULTIPLIER);
+		}
+
 		if($this->punchKnockback > 0){
 			$horizontalSpeed = sqrt($this->motion->x ** 2 + $this->motion->z ** 2);
 			if($horizontalSpeed > 0){

--- a/src/item/Crossbow.php
+++ b/src/item/Crossbow.php
@@ -1,0 +1,325 @@
+<?php
+
+/*
+ *
+ *      _    _ _
+ *     / \  | | |_ __ _ _   _
+ *    / _ \ | | __/ _` | | | |
+ *   / ___ \| | || (_| | |_| |
+ *  /_/   \_\_|\__\__,_|\__, |
+ *                       |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Original work by the PocketMine Team.
+ * https://www.pocketmine.net/
+ *
+ * @author Altay Team
+ * @link https://github.com/altayofficial
+ */
+
+declare(strict_types=1);
+
+namespace pocketmine\item;
+
+use pocketmine\data\bedrock\item\ItemTypeNames;
+use pocketmine\entity\Location;
+use pocketmine\entity\object\CrossbowFireworkRocket;
+use pocketmine\entity\projectile\Arrow as ArrowEntity;
+use pocketmine\entity\projectile\Projectile;
+use pocketmine\event\entity\EntityShootBowEvent;
+use pocketmine\event\entity\ProjectileLaunchEvent;
+use pocketmine\inventory\Inventory;
+use pocketmine\item\enchantment\VanillaEnchantments;
+use pocketmine\math\Vector3;
+use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\player\Player;
+use pocketmine\world\sound\CrossbowLoadingEndSound;
+use pocketmine\world\sound\CrossbowShootSound;
+use function cos;
+use function max;
+use function mt_rand;
+use function sin;
+use const M_PI;
+
+class Crossbow extends Tool implements Releasable{
+
+	private const TAG_CHARGED_ITEM = "chargedItem";
+	private const TAG_CHARGED_ITEM_NAME = "Name";
+	private const TAG_CHARGED_ITEM_COUNT = "Count";
+	private const TAG_CHARGED_ITEM_DAMAGE = "Damage";
+	private const TAG_CHARGED_ITEM_TAG = "tag";
+
+	/**
+	 * Time the crossbow has to be held down before it becomes loaded, before Quick Charge is applied.
+	 */
+	public const CHARGE_DURATION = 25;
+
+	/**
+	 * Ticks removed from the charge duration by each level of Quick Charge.
+	 */
+	public const QUICK_CHARGE_REDUCTION = 5;
+
+	public const SHOOT_FORCE = 3.15;
+
+	public const FIREWORK_SHOOT_FORCE = 1.6;
+
+	/**
+	 * A firework rocket fired from a crossbow explodes on its own after this many ticks, plus a random extra.
+	 */
+	private const FIREWORK_FLIGHT_TIME = 10;
+
+	private const FIREWORK_FLIGHT_TIME_RANDOM = 12;
+
+	/**
+	 * Angle in degrees between the middle projectile and each of the two side ones fired by Multishot.
+	 */
+	private const MULTISHOT_ANGLE = 10.0;
+
+	private const DURABILITY_COST = 1;
+
+	private const DURABILITY_COST_MULTISHOT = 3;
+
+	private const DURABILITY_COST_FIREWORK = 3;
+
+	private ?Item $chargedItem = null;
+
+	public function getFuelTime() : int{
+		return 200;
+	}
+
+	public function getMaxDurability() : int{
+		return 465;
+	}
+
+	public function isCharged() : bool{
+		return $this->chargedItem !== null;
+	}
+
+	/**
+	 * Returns the ammo the crossbow is loaded with, or null if it isn't loaded.
+	 */
+	public function getChargedItem() : ?Item{
+		return $this->chargedItem === null ? null : clone $this->chargedItem;
+	}
+
+	/** @return $this */
+	public function setChargedItem(?Item $item) : self{
+		if($item !== null && !self::isAmmo($item)){
+			throw new \InvalidArgumentException("A crossbow can only be charged with an arrow or a firework rocket");
+		}
+		$this->chargedItem = $item === null ? null : (clone $item)->setCount(1);
+		return $this;
+	}
+
+	public static function isAmmo(Item $item) : bool{
+		return $item->getTypeId() === ItemTypeIds::ARROW || $item instanceof FireworkRocket;
+	}
+
+	protected function deserializeCompoundTag(CompoundTag $tag) : void{
+		parent::deserializeCompoundTag($tag);
+
+		$this->chargedItem = null;
+
+		$chargedItem = $tag->getCompoundTag(self::TAG_CHARGED_ITEM);
+		if($chargedItem === null || $chargedItem->getByte(self::TAG_CHARGED_ITEM_COUNT, 0) <= 0){
+			return;
+		}
+
+		$item = $chargedItem->getString(self::TAG_CHARGED_ITEM_NAME, ItemTypeNames::ARROW) === ItemTypeNames::FIREWORK_ROCKET ?
+			VanillaItems::FIREWORK_ROCKET() :
+			VanillaItems::ARROW();
+
+		$itemTag = $chargedItem->getCompoundTag(self::TAG_CHARGED_ITEM_TAG);
+		if($itemTag !== null){
+			$item->setNamedTag($itemTag);
+		}
+
+		$this->chargedItem = $item;
+	}
+
+	protected function serializeCompoundTag(CompoundTag $tag) : void{
+		parent::serializeCompoundTag($tag);
+
+		if($this->chargedItem === null){
+			$tag->removeTag(self::TAG_CHARGED_ITEM);
+			return;
+		}
+
+		//the client renders the loaded crossbow from this tag
+		$chargedItem = CompoundTag::create()
+			->setByte(self::TAG_CHARGED_ITEM_COUNT, 1)
+			->setShort(self::TAG_CHARGED_ITEM_DAMAGE, 0)
+			->setString(self::TAG_CHARGED_ITEM_NAME, $this->chargedItem instanceof FireworkRocket ? ItemTypeNames::FIREWORK_ROCKET : ItemTypeNames::ARROW);
+
+		//keeps the explosions of a loaded firework rocket
+		$itemTag = $this->chargedItem->getNamedTag();
+		if($itemTag->count() > 0){
+			$chargedItem->setTag(self::TAG_CHARGED_ITEM_TAG, $itemTag);
+		}
+
+		$tag->setTag(self::TAG_CHARGED_ITEM, $chargedItem);
+	}
+
+	public function canStartUsingItem(Player $player) : bool{
+		return !$this->isCharged() && ($this->findAmmo($player) !== null || !$player->hasFiniteResources());
+	}
+
+	public function getMinUseDuration() : int{
+		return $this->getChargeDuration();
+	}
+
+	/**
+	 * Returns how long the crossbow has to be held down before it becomes loaded, Quick Charge included.
+	 */
+	public function getChargeDuration() : int{
+		$quickCharge = $this->getEnchantmentLevel(VanillaEnchantments::QUICK_CHARGE());
+
+		return max(0, self::CHARGE_DURATION - ($quickCharge * self::QUICK_CHARGE_REDUCTION));
+	}
+
+	public function onReleaseUsing(Player $player, array &$returnedItems) : ItemUseResult{
+		if($this->isCharged() || $player->getItemUseDuration() < $this->getChargeDuration()){
+			return ItemUseResult::NONE;
+		}
+
+		$ammo = $this->findAmmo($player);
+		if(!$player->hasFiniteResources()){
+			$this->setChargedItem($ammo === null ? VanillaItems::ARROW() : $ammo[1]);
+		}else{
+			if($ammo === null){
+				return ItemUseResult::FAIL;
+			}
+
+			[$inventory, $item] = $ammo;
+			$this->setChargedItem($item);
+			$inventory->removeItem((clone $item)->setCount(1));
+		}
+
+		$player->getWorld()->addSound($player->getPosition(), new CrossbowLoadingEndSound());
+
+		return ItemUseResult::SUCCESS;
+	}
+
+	public function onClickAir(Player $player, Vector3 $directionVector, array &$returnedItems) : ItemUseResult{
+		$chargedItem = $this->chargedItem;
+		if($chargedItem === null){
+			return ItemUseResult::NONE;
+		}
+
+		$multishot = $this->hasEnchantment(VanillaEnchantments::MULTISHOT());
+		$angles = $multishot ? [-self::MULTISHOT_ANGLE, 0.0, self::MULTISHOT_ANGLE] : [0.0];
+
+		$fired = 0;
+		foreach($angles as $angle){
+			if($this->shoot($player, $chargedItem, $angle)){
+				$fired++;
+			}
+		}
+
+		if($fired === 0){
+			return ItemUseResult::FAIL;
+		}
+
+		$this->chargedItem = null;
+		if($player->hasFiniteResources()){
+			$this->applyDamage(match(true){
+				$chargedItem instanceof FireworkRocket => self::DURABILITY_COST_FIREWORK,
+				$multishot => self::DURABILITY_COST_MULTISHOT,
+				default => self::DURABILITY_COST
+			});
+		}
+
+		return ItemUseResult::SUCCESS;
+	}
+
+	/**
+	 * Fires a single projectile, rotated horizontally by the given angle in degrees.
+	 */
+	private function shoot(Player $player, Item $ammo, float $angle) : bool{
+		$location = $player->getLocation();
+		$yaw = $location->yaw + $angle;
+		$origin = Location::fromObject(
+			$player->getEyePos(),
+			$player->getWorld(),
+			($yaw > 180 ? 360 : 0) - $yaw,
+			-$location->pitch
+		);
+		$direction = $this->getDirectionVector($yaw, $location->pitch);
+
+		if($ammo instanceof FireworkRocket){
+			$entity = new CrossbowFireworkRocket($origin, self::FIREWORK_FLIGHT_TIME + mt_rand(0, self::FIREWORK_FLIGHT_TIME_RANDOM), $ammo->getExplosions());
+			$entity->setOwningEntity($player);
+			$entity->setMotion($direction->multiply(self::FIREWORK_SHOOT_FORCE));
+			$entity->spawnToAll();
+			$player->getWorld()->addSound($location, new CrossbowShootSound());
+
+			return true;
+		}
+
+		$entity = new ArrowEntity($origin, $player, true);
+		$entity->setMotion($direction);
+		$entity->setPiercing($this->getEnchantmentLevel(VanillaEnchantments::PIERCING()));
+
+		$ev = new EntityShootBowEvent($player, $this, $entity, self::SHOOT_FORCE);
+		if($player->isSpectator()){
+			$ev->cancel();
+		}
+		$ev->call();
+
+		$entity = $ev->getProjectile(); //this might have been changed by plugins
+
+		if($ev->isCancelled()){
+			$entity->flagForDespawn();
+			return false;
+		}
+
+		$entity->setMotion($entity->getMotion()->multiply($ev->getForce()));
+
+		if($entity instanceof Projectile){
+			$projectileEv = new ProjectileLaunchEvent($entity);
+			$projectileEv->call();
+			if($projectileEv->isCancelled()){
+				$entity->flagForDespawn();
+				return false;
+			}
+		}
+
+		$entity->spawnToAll();
+		$player->getWorld()->addSound($location, new CrossbowShootSound());
+
+		return true;
+	}
+
+	private function getDirectionVector(float $yaw, float $pitch) : Vector3{
+		$pitchRad = $pitch * (M_PI / 180);
+		$yawRad = $yaw * (M_PI / 180);
+
+		return (new Vector3(
+			-sin($yawRad) * cos($pitchRad),
+			-sin($pitchRad),
+			cos($yawRad) * cos($pitchRad)
+		))->normalize();
+	}
+
+	/**
+	 * Returns the inventory holding the first usable ammo and the ammo itself, or null if the player has none.
+	 * The offhand is searched first, like vanilla does.
+	 *
+	 * @phpstan-return array{Inventory, Item}|null
+	 */
+	private function findAmmo(Player $player) : ?array{
+		foreach([$player->getOffHandInventory(), $player->getInventory()] as $inventory){
+			foreach($inventory->getContents() as $item){
+				if(self::isAmmo($item)){
+					return [$inventory, $item];
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/item/ItemTypeIds.php
+++ b/src/item/ItemTypeIds.php
@@ -380,8 +380,9 @@ final class ItemTypeIds{
 	public const STONE_SPEAR = 20339;
 	public const WOODEN_SPEAR = 20340;
 	public const MACE = 20341;
+	public const CROSSBOW = 20342;
 
-	public const FIRST_UNUSED_ITEM_ID = 20342;
+	public const FIRST_UNUSED_ITEM_ID = 20343;
 
 	private static int $nextDynamicId = self::FIRST_UNUSED_ITEM_ID;
 

--- a/src/item/StringToItemParser.php
+++ b/src/item/StringToItemParser.php
@@ -1424,6 +1424,7 @@ final class StringToItemParser extends StringToTParser{
 		$result->register("copper_shovel", fn() => Items::COPPER_SHOVEL());
 		$result->register("copper_sword", fn() => Items::COPPER_SWORD());
 		$result->register("crimson_hanging_sign", fn() => Items::CRIMSON_HANGING_SIGN());
+		$result->register("crossbow", fn() => Items::CROSSBOW());
 		$result->register("dark_oak_boat", fn() => Items::DARK_OAK_BOAT());
 		$result->register("dark_oak_hanging_sign", fn() => Items::DARK_OAK_HANGING_SIGN());
 		$result->register("diamond", fn() => Items::DIAMOND());

--- a/src/item/VanillaItemsInputs.php
+++ b/src/item/VanillaItemsInputs.php
@@ -184,6 +184,7 @@ final class VanillaItemsInputs extends RegistrySource{
 		self::register("copper_ingot", fn(IID $id) => new Item($id, "Copper Ingot"));
 		self::register("copper_nugget", fn(IID $id) => new Item($id, "Copper Nugget"));
 		self::registerDelayed("coral_fan", fn(string $name) : CoralFan => new CoralFan(self::makeIID($name))); //uses VanillaBlocks in constructor :(
+		self::register("crossbow", fn(IID $id) => new Crossbow($id, "Crossbow", [EnchantmentTags::CROSSBOW]));
 		self::registerDelayed("crimson_sign", fn(string $name) : ItemBlockWallOrFloor => new ItemBlockWallOrFloor(self::makeIID($name), Blocks::CRIMSON_SIGN(), Blocks::CRIMSON_WALL_SIGN()));
 		self::registerDelayed("crimson_hanging_sign", fn(string $name) : HangingSign => new HangingSign(self::makeIID($name), "Crimson Hanging Sign", Blocks::CRIMSON_CEILING_CENTER_HANGING_SIGN(), Blocks::CRIMSON_CEILING_EDGES_HANGING_SIGN(), Blocks::CRIMSON_WALL_HANGING_SIGN()));
 		self::registerDelayed("dark_oak_sign", fn(string $name) : ItemBlockWallOrFloor => new ItemBlockWallOrFloor(self::makeIID($name), Blocks::DARK_OAK_SIGN(), Blocks::DARK_OAK_WALL_SIGN()));

--- a/src/item/enchantment/AvailableEnchantmentRegistry.php
+++ b/src/item/enchantment/AvailableEnchantmentRegistry.php
@@ -76,6 +76,9 @@ final class AvailableEnchantmentRegistry{
 			[Tags::ARMOR, Tags::WEAPONS, Tags::FISHING_ROD],
 			[Tags::SHEARS, Tags::FLINT_AND_STEEL, Tags::SHIELD, Tags::CARROT_ON_STICK, Tags::ELYTRA, Tags::BRUSH]
 		);
+		$this->register(Enchantments::MULTISHOT(), [Tags::CROSSBOW], []);
+		$this->register(Enchantments::PIERCING(), [Tags::CROSSBOW], []);
+		$this->register(Enchantments::QUICK_CHARGE(), [Tags::CROSSBOW], []);
 		$this->register(Enchantments::POWER(), [Tags::BOW], []);
 		$this->register(Enchantments::PUNCH(), [Tags::BOW], []);
 		$this->register(Enchantments::FLAME(), [Tags::BOW], []);

--- a/src/item/enchantment/IncompatibleEnchantmentRegistry.php
+++ b/src/item/enchantment/IncompatibleEnchantmentRegistry.php
@@ -50,6 +50,7 @@ final class IncompatibleEnchantmentRegistry{
 		$this->register(Groups::BOW_INFINITE, [Enchantments::INFINITY(), Enchantments::MENDING()]);
 		$this->register(Groups::BLOCK_DROPS, [Enchantments::FORTUNE(), Enchantments::SILK_TOUCH()]);
 		$this->register(Groups::HEAVY_WEAPON_DAMAGE, [Enchantments::DENSITY(), Enchantments::BREACH()]);
+		$this->register(Groups::CROSSBOW_PROJECTILE, [Enchantments::MULTISHOT(), Enchantments::PIERCING()]);
 	}
 
 	/**

--- a/src/item/enchantment/StringToEnchantmentParser.php
+++ b/src/item/enchantment/StringToEnchantmentParser.php
@@ -53,7 +53,10 @@ final class StringToEnchantmentParser extends StringToTParser{
 		$result->register("knockback", fn() => VanillaEnchantments::KNOCKBACK());
 		$result->register("lunge", fn() => VanillaEnchantments::LUNGE());
 		$result->register("mending", fn() => VanillaEnchantments::MENDING());
+		$result->register("multishot", fn() => VanillaEnchantments::MULTISHOT());
+		$result->register("piercing", fn() => VanillaEnchantments::PIERCING());
 		$result->register("power", fn() => VanillaEnchantments::POWER());
+		$result->register("quick_charge", fn() => VanillaEnchantments::QUICK_CHARGE());
 		$result->register("projectile_protection", fn() => VanillaEnchantments::PROJECTILE_PROTECTION());
 		$result->register("protection", fn() => VanillaEnchantments::PROTECTION());
 		$result->register("punch", fn() => VanillaEnchantments::PUNCH());

--- a/src/item/enchantment/VanillaEnchantmentsInputs.php
+++ b/src/item/enchantment/VanillaEnchantmentsInputs.php
@@ -301,6 +301,36 @@ final class VanillaEnchantmentsInputs extends RegistrySource{
 			20
 		));
 
+		self::register("MULTISHOT", new Enchantment(
+			KnownTranslationFactory::enchantment_crossbowMultishot(),
+			Rarity::RARE,
+			0,
+			0,
+			1,
+			fn(int $level) : int => 20,
+			50
+		));
+
+		self::register("PIERCING", new Enchantment(
+			KnownTranslationFactory::enchantment_crossbowPiercing(),
+			Rarity::COMMON,
+			0,
+			0,
+			4,
+			fn(int $level) : int => 10 * ($level - 1) + 1,
+			50
+		));
+
+		self::register("QUICK_CHARGE", new Enchantment(
+			KnownTranslationFactory::enchantment_crossbowQuickCharge(),
+			Rarity::UNCOMMON,
+			0,
+			0,
+			3,
+			fn(int $level) : int => 20 * ($level - 1) + 12,
+			50
+		));
+
 		self::register("SWIFT_SNEAK", new Enchantment(
 			KnownTranslationFactory::enchantment_swift_sneak(),
 			Rarity::MYTHIC,

--- a/src/world/sound/CrossbowLoadingEndSound.php
+++ b/src/world/sound/CrossbowLoadingEndSound.php
@@ -23,16 +23,15 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\sound;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
-	public const CROSSBOW_PROJECTILE = "crossbow_projectile";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class CrossbowLoadingEndSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::CROSSBOW_LOADING_END, $pos, false)];
+	}
 }

--- a/src/world/sound/CrossbowShootSound.php
+++ b/src/world/sound/CrossbowShootSound.php
@@ -23,16 +23,15 @@
 
 declare(strict_types=1);
 
-namespace pocketmine\item\enchantment;
+namespace pocketmine\world\sound;
 
-/**
- * Constants for groupings of incompatible enchantments.
- * Enchantments belonging to the same incompatibility group cannot be applied side-by-side on the same item.
- */
-final class IncompatibleEnchantmentGroups{
-	public const PROTECTION = "protection";
-	public const BOW_INFINITE = "bow_infinite";
-	public const BLOCK_DROPS = "block_drops";
-	public const HEAVY_WEAPON_DAMAGE = "heavy_weapon_damage";
-	public const CROSSBOW_PROJECTILE = "crossbow_projectile";
+use pocketmine\math\Vector3;
+use pocketmine\network\mcpe\protocol\LevelSoundEventPacket;
+use pocketmine\network\mcpe\protocol\types\LevelSoundEvent;
+
+class CrossbowShootSound implements Sound{
+
+	public function encode(Vector3 $pos) : array{
+		return [LevelSoundEventPacket::nonActorSound(LevelSoundEvent::CROSSBOW_SHOOT, $pos, false)];
+	}
 }


### PR DESCRIPTION
Added the crossbow to Altay, along with its three enchantments.

## Changes

### API changes

- Added `Crossbow`, with `isCharged()`, `setCharged()` and `getChargeDuration()`, which returns the charge time with Quick Charge applied.
- Added `Arrow::getPiercing()` and `Arrow::setPiercing()`, along with the `Arrow::despawnsOnEntityHit()` and `Arrow::canCollideWith()` overrides that make piercing work.
- Added the `MULTISHOT`, `PIERCING` and `QUICK_CHARGE` enchantments, registered in `VanillaEnchantments`, `EnchantmentIdMap`, `AvailableEnchantmentRegistry` and `StringToEnchantmentParser`.
- Added the `IncompatibleEnchantmentGroups::CROSSBOW_PROJECTILE` group, which makes Multishot and Piercing mutually incompatible.
- Added `CrossbowLoadingEndSound` and `CrossbowShootSound`.
- Added `CrossbowFireworkRocket`, a firework rocket that flies straight instead of climbing, and explodes on contact with a living entity.
- `Crossbow::getChargedItem()` and `setChargedItem()` replace the earlier boolean, since the crossbow now remembers which ammo it holds.

### Behavioural changes

- Quick Charge removes 5 ticks of charge time per level, taking it from 25 ticks down to 10 at level III.
- Multishot fires three arrows 10 degrees apart for a single arrow consumed, and costs three points of durability instead of one.
- Piercing lets the arrow go through one more entity per level. 
- The crossbow also accepts firework rockets. A loaded rocket keeps its explosions, so the firework that comes out is the one that went in. It is fired at a speed of 1.6, explodes on impact or after 10 to 22 ticks, and costs three points of durability.

## Backwards compatibility


## Tests

The Multishot/Piercing incompatibility, the Quick Charge timings.